### PR TITLE
Rename addon title to "HDHomeRun PVR Client Addon"

### DIFF
--- a/pvr.hdhomerun/addon.xml.in
+++ b/pvr.hdhomerun/addon.xml.in
@@ -2,7 +2,7 @@
 <addon
   id="pvr.hdhomerun"
   version="2.2.1"
-  name="PVR HDHomeRun Client"
+  name="HDHomeRun PVR Client Addon"
   provider-name="Zoltan Csizmadia (zcsizmadia@gmail.com)">
   <requires>
     <c-pluff version="0.1"/>


### PR DESCRIPTION
Suggest renaming of the addon title to "HDHomeRun PVR Client Addon" just to try to make it a little more clear and more consistant with the naming standard of the other PVR client addons for Kodi.