### PR TITLE
Use correct channel number parsed from GuideNumber

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,6 @@ before_script:
   - cd $TRAVIS_BUILD_DIR/..
   - git clone --depth=1 https://github.com/xbmc/xbmc.git
   - cd pvr.hdhomerun && mkdir build && cd build
-  - cmake -DADDONS_TO_BUILD=pvr.hdhomerun -DADDON_SRC_PREFIX=$TRAVIS_BUILD_DIR/.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../xbmc/addons -DPACKAGE_ZIP=1 $TRAVIS_BUILD_DIR/../xbmc/project/cmake/addons
+  - cmake -DADDONS_TO_BUILD=pvr.hdhomerun -DADDON_SRC_PREFIX=$TRAVIS_BUILD_DIR/.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../xbmc/addons -DPACKAGE_ZIP=1 $TRAVIS_BUILD_DIR/../xbmc/cmake/addons
 
 script: make

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ HDHomeRun PVR client addon for [Kodi] (http://kodi.tv)
 1. `git clone https://github.com/xbmc/xbmc.git`
 2. `git clone https://github.com/kodi-pvr/pvr.hdhomerun.git`
 3. `cd pvr.hdhomerun && mkdir build && cd build`
-4. `cmake -DADDONS_TO_BUILD=pvr.hdhomerun -DADDON_SRC_PREFIX=../.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../../xbmc/addons -DPACKAGE_ZIP=1 ../../xbmc/project/cmake/addons`
+4. `cmake -DADDONS_TO_BUILD=pvr.hdhomerun -DADDON_SRC_PREFIX=../.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../../xbmc/addons -DPACKAGE_ZIP=1 ../../xbmc/cmake/addons`
 5. `make`
 
 ### Windows 
@@ -20,7 +20,7 @@ HDHomeRun PVR client addon for [Kodi] (http://kodi.tv)
 4. `cd pvr.hdhomerun`
 5. `mkdir build`
 6. `cd build`
-7. `cmake -G "Visual Studio 14" -DADDONS_TO_BUILD=pvr.hdhomerun -DCMAKE_BUILD_TYPE=Debug -DADDON_SRC_PREFIX=%ROOT% -DCMAKE_INSTALL_PREFIX=%ROOT%\xbmc\addons -DCMAKE_USER_MAKE_RULES_OVERRIDE=%ROOT%\xbmc\project\cmake\scripts\windows\c-flag-overrides.cmake -DCMAKE_USER_MAKE_RULES_OVERRIDE_CXX=%ROOT%\xbmc\project\cmake\scripts\windows\cxx-flag-overrides.cmake -DPACKAGE_ZIP=1 %ROOT%\xbmc\project\cmake\addons`
+7. `cmake -G "Visual Studio 14" -DADDONS_TO_BUILD=pvr.hdhomerun -DCMAKE_BUILD_TYPE=Debug -DADDON_SRC_PREFIX=%ROOT% -DCMAKE_INSTALL_PREFIX=%ROOT%\xbmc\addons -DCMAKE_USER_MAKE_RULES_OVERRIDE=%ROOT%\xbmc\project\cmake\scripts\windows\c-flag-overrides.cmake -DCMAKE_USER_MAKE_RULES_OVERRIDE_CXX=%ROOT%\xbmc\project\cmake\scripts\windows\cxx-flag-overrides.cmake -DPACKAGE_ZIP=1 %ROOT%\xbmc\cmake\addons`
 8. `cmake --build . --config Debug`
 
 ## Useful links

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,5 +29,5 @@ build_script:
   - mkdir build
   - cd build
   # Must use absolute path for cmake to build depends correctly
-  - cmake -G "%GENERATOR%" -DADDONS_TO_BUILD=%ADDON% -DCMAKE_BUILD_TYPE=%CONFIG% -DADDON_SRC_PREFIX=%ROOT% -DCMAKE_INSTALL_PREFIX=%ROOT%\xbmc\addons -DCMAKE_USER_MAKE_RULES_OVERRIDE=%ROOT%\xbmc\project\cmake\scripts\windows\c-flag-overrides.cmake -DCMAKE_USER_MAKE_RULES_OVERRIDE_CXX=%ROOT%\xbmc\project\cmake\scripts\windows\cxx-flag-overrides.cmake -DPACKAGE_ZIP=1 %ROOT%\xbmc\project\cmake\addons
+  - cmake -G "%GENERATOR%" -DADDONS_TO_BUILD=%ADDON% -DCMAKE_BUILD_TYPE=%CONFIG% -DADDON_SRC_PREFIX=%ROOT% -DCMAKE_INSTALL_PREFIX=%ROOT%\xbmc\addons -DCMAKE_USER_MAKE_RULES_OVERRIDE=%ROOT%\xbmc\project\cmake\scripts\windows\c-flag-overrides.cmake -DCMAKE_USER_MAKE_RULES_OVERRIDE_CXX=%ROOT%\xbmc\project\cmake\scripts\windows\cxx-flag-overrides.cmake -DPACKAGE_ZIP=1 %ROOT%\xbmc\cmake\addons
   - cmake --build . --config %CONFIG%

--- a/pvr.hdhomerun/addon.xml.in
+++ b/pvr.hdhomerun/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hdhomerun"
-  version="3.0.1"
+  version="3.0.2"
   name="PVR HDHomeRun Client"
   provider-name="Zoltan Csizmadia (zcsizmadia@gmail.com)">
   <requires>

--- a/pvr.hdhomerun/changelog.txt
+++ b/pvr.hdhomerun/changelog.txt
@@ -1,3 +1,6 @@
+v3.0.2
+- Correct channel Number if back-end provided channel number is used
+
 v3.0.0
 - Initial Kodi v18 version
 


### PR DESCRIPTION
If "Use channel numbers from backend" is selected in PVR settings, the channel number (and sub-channel number) is parsed from GuideNumber from lineup.json.