### PR TITLE
Only use Guide's Affiliate if ChannelName not set

### DIFF
--- a/src/HDHomeRunTuners.cpp
+++ b/src/HDHomeRunTuners.cpp
@@ -216,7 +216,8 @@ bool HDHomeRunTuners::Update(int nMode)
             const Json::Value& jsonGuide = pTuner->Guide[nGuideIndex];
             if (jsonGuide["GuideNumber"].asString() == jsonChannel["GuideNumber"].asString())
             {
-              jsonChannel["_ChannelName"] = jsonGuide["Affiliate"].asString();
+			        if (jsonChannel["_ChannelName"] == "" && jsonGuide["Affiliate"].asString() != "")
+			          jsonChannel["_ChannelName"] = jsonGuide["Affiliate"].asString();
               jsonChannel["_IconPath"] = jsonGuide["ImageURL"].asString();
               break;
             }


### PR DESCRIPTION
If ChannelName was already set it would still try and set it with Guide's Affiliate causing channels with no Affiliate to become unknown channels. Now only tries and does that if ChannelName is not set and Guide has an Affiliate.