### PR TITLE
 Only use Guide's Affiliate if ChannelName not set #34 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ HDHomeRun PVR client addon for [Kodi] (http://kodi.tv)
 4. `cd pvr.hdhomerun`
 5. `mkdir build`
 6. `cd build`
-7. `cmake -G "Visual Studio 14" -DADDONS_TO_BUILD=pvr.hdhomerun -DCMAKE_BUILD_TYPE=Debug -DADDON_SRC_PREFIX=%ROOT% -DCMAKE_INSTALL_PREFIX=%ROOT%\xbmc\addons -DCMAKE_USER_MAKE_RULES_OVERRIDE=%ROOT%\xbmc\project\cmake\scripts\windows\c-flag-overrides.cmake -DCMAKE_USER_MAKE_RULES_OVERRIDE_CXX=%ROOT%\xbmc\project\cmake\scripts\windows\cxx-flag-overrides.cmake -DPACKAGE_ZIP=1 %ROOT%\xbmc\cmake\addons`
-8. `cmake --build . --config Debug`
+7. `cmake -G "Visual Studio 14" -DADDONS_TO_BUILD=pvr.hdhomerun -DCMAKE_BUILD_TYPE=Release-DADDON_SRC_PREFIX=%ROOT% -DCMAKE_INSTALL_PREFIX=%ROOT%\xbmc\addons -DCMAKE_USER_MAKE_RULES_OVERRIDE=%ROOT%\xbmc\cmake\scripts\windows\CFlagOverrides.cmake -DCMAKE_USER_MAKE_RULES_OVERRIDE_CXX=%ROOT%\xbmc\cmake\scripts\windows\CXXFlagOverrides.cmake -DPACKAGE_ZIP=1 %ROOT%\xbmc\cmake\addons`
+8. `cmake --build . --config Release`
 
 ## Useful links
 

--- a/pvr.hdhomerun/addon.xml.in
+++ b/pvr.hdhomerun/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hdhomerun"
-  version="3.0.2"
+  version="3.0.3"
   name="PVR HDHomeRun Client"
   provider-name="Zoltan Csizmadia (zcsizmadia@gmail.com)">
   <requires>

--- a/pvr.hdhomerun/changelog.txt
+++ b/pvr.hdhomerun/changelog.txt
@@ -1,3 +1,6 @@
+v3.0.3
+- Fixed issue where some channels that were supposed to have a name did not.
+
 v3.0.2
 - Correct channel Number if back-end provided channel number is used
 

--- a/src/HDHomeRunTuners.cpp
+++ b/src/HDHomeRunTuners.cpp
@@ -216,8 +216,8 @@ bool HDHomeRunTuners::Update(int nMode)
             const Json::Value& jsonGuide = pTuner->Guide[nGuideIndex];
             if (jsonGuide["GuideNumber"].asString() == jsonChannel["GuideNumber"].asString())
             {
-			        if (jsonChannel["_ChannelName"] == "" && jsonGuide["Affiliate"].asString() != "")
-			          jsonChannel["_ChannelName"] = jsonGuide["Affiliate"].asString();
+              if (jsonChannel["_ChannelName"] == "" && jsonGuide["Affiliate"].asString() != "")
+                jsonChannel["_ChannelName"] = jsonGuide["Affiliate"].asString();
               jsonChannel["_IconPath"] = jsonGuide["ImageURL"].asString();
               break;
             }

--- a/src/HDHomeRunTuners.cpp
+++ b/src/HDHomeRunTuners.cpp
@@ -216,7 +216,8 @@ bool HDHomeRunTuners::Update(int nMode)
             const Json::Value& jsonGuide = pTuner->Guide[nGuideIndex];
             if (jsonGuide["GuideNumber"].asString() == jsonChannel["GuideNumber"].asString())
             {
-              jsonChannel["_ChannelName"] = jsonGuide["Affiliate"].asString();
+			        if (jsonChannel["_ChannelName"] == "" && jsonGuide["Affiliate"].asString() != "")
+			          jsonChannel["_ChannelName"] = jsonGuide["Affiliate"].asString();
               jsonChannel["_IconPath"] = jsonGuide["ImageURL"].asString();
               break;
             }


### PR DESCRIPTION
If ChannelName was already set it would still set it with Guide's Affiliate causing channels with no Affiliate to become unknown channels. Changed it to only try to update it if ChannelName is not set and Guide has a valid Affiliate.