### PR TITLE
Minimalist Update to PVR API 5.5.0

### DIFF
--- a/depends/common/hdhomerun/hdhomerun.txt
+++ b/depends/common/hdhomerun/hdhomerun.txt
@@ -1,1 +1,1 @@
-hdhomerun https://github.com/Silicondust/libhdhomerun 1efbcb2b87b17a82f2b3d873d1c9cc1c6a3a9b77
+hdhomerun https://github.com/Silicondust/libhdhomerun 5a22c0fde9c58279641d30372ddbdbdd48e0a300

--- a/pvr.hdhomerun/addon.xml.in
+++ b/pvr.hdhomerun/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hdhomerun"
-  version="3.1.0"
+  version="3.1.1"
   name="PVR HDHomeRun Client"
   provider-name="Zoltan Csizmadia (zcsizmadia@gmail.com)">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hdhomerun/changelog.txt
+++ b/pvr.hdhomerun/changelog.txt
@@ -1,3 +1,6 @@
+v3.1.1
+- Update to PVR addon API v5.5.0
+
 v3.1.0
 - Update to PVR addon API v5.3.0
 

--- a/pvr.hdhomerun/changelog.txt
+++ b/pvr.hdhomerun/changelog.txt
@@ -1,5 +1,6 @@
 v3.1.1
 - Update to PVR addon API v5.5.0
+- Implement GetLiveStreamURL
 
 v3.1.0
 - Update to PVR addon API v5.3.0

--- a/src/HDHomeRunTuners.cpp
+++ b/src/HDHomeRunTuners.cpp
@@ -296,7 +296,6 @@ PVR_ERROR HDHomeRunTuners::PvrGetChannels(ADDON_HANDLE handle, bool bRadio)
       pvrChannel.iChannelNumber = jsonChannel["_ChannelNumber"].asUInt();
       pvrChannel.iSubChannelNumber = jsonChannel["_SubChannelNumber"].asUInt();
       PVR_STRCPY(pvrChannel.strChannelName, jsonChannel["_ChannelName"].asString().c_str());
-      PVR_STRCPY(pvrChannel.strStreamURL, jsonChannel["URL"].asString().c_str());
       PVR_STRCPY(pvrChannel.strIconPath, jsonChannel["_IconPath"].asString().c_str());
       
       g.PVR->TransferChannelEntry(handle, &pvrChannel);

--- a/src/HDHomeRunTuners.cpp
+++ b/src/HDHomeRunTuners.cpp
@@ -422,3 +422,26 @@ PVR_ERROR HDHomeRunTuners::PvrGetChannelGroupMembers(ADDON_HANDLE handle, const 
 
   return PVR_ERROR_NO_ERROR;
 }
+
+std::string HDHomeRunTuners::_GetLiveStreamURL(const PVR_CHANNEL &channel) 
+{  
+    PVR_CHANNEL pvrChannel;
+    Json::Value::ArrayIndex nIndex;
+
+    AutoLock l(this);
+  
+    for (Tuners::const_iterator iterTuner = m_Tuners.begin(); iterTuner != m_Tuners.end(); iterTuner++)
+    {
+        for (nIndex = 0; nIndex < iterTuner->LineUp.size(); nIndex++)
+        {
+            const Json::Value& jsonChannel = iterTuner->LineUp[nIndex];
+		
+            if (jsonChannel["_UID"].asUInt() == channel.iUniqueId)
+            {
+                std::string url = jsonChannel["URL"].asString();
+                return url;
+            }
+        }
+    }        
+    return "";
+}

--- a/src/HDHomeRunTuners.h
+++ b/src/HDHomeRunTuners.h
@@ -76,6 +76,7 @@ public:
 	int PvrGetChannelGroupsAmount(void);
 	PVR_ERROR PvrGetChannelGroups(ADDON_HANDLE handle, bool bRadio);
 	PVR_ERROR PvrGetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &group);
+	std::string _GetLiveStreamURL(const PVR_CHANNEL &channel);
 	
 protected:
 	unsigned int PvrCalculateUniqueId(const String& str);

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -300,7 +300,13 @@ bool CanSeekStream(void)
 { 
   return true; 
 }
-
+  
+const char * GetLiveStreamURL(const PVR_CHANNEL &channel) 
+{ 
+  static std::string urlreturn = g.Tuners->_GetLiveStreamURL(channel);
+  return urlreturn.c_str();
+}
+  
 /* UNUSED API FUNCTIONS */
 PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook, const PVR_MENUHOOK_DATA &item) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR GetStreamProperties(PVR_STREAM_PROPERTIES* pProperties) { return PVR_ERROR_NOT_IMPLEMENTED; }
@@ -326,7 +332,6 @@ int ReadLiveStream(unsigned char *pBuffer, unsigned int iBufferSize) { return 0;
 long long SeekLiveStream(long long iPosition, int iWhence /* = SEEK_SET */) { return -1; }
 long long PositionLiveStream(void) { return -1; }
 long long LengthLiveStream(void) { return -1; }
-const char * GetLiveStreamURL(const PVR_CHANNEL &channel) { return ""; }
 PVR_ERROR DeleteRecording(const PVR_RECORDING &recording) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR RenameRecording(const PVR_RECORDING &recording) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR SetRecordingPlayCount(const PVR_RECORDING &recording, int count) { return PVR_ERROR_NOT_IMPLEMENTED; }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -283,13 +283,6 @@ void CloseLiveStream(void)
   g.iCurrentChannelUniqueId = 0;
 }
 
-bool SwitchChannel(const PVR_CHANNEL &channel)
-{
-  CloseLiveStream();
-
-  return OpenLiveStream(channel);
-}
-
 PVR_ERROR SignalStatus(PVR_SIGNAL_STATUS &signalStatus)
 {
   PVR_STRCPY(signalStatus.strAdapterName, "PVR HDHomeRun Adapter 1");
@@ -345,7 +338,6 @@ PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete) { return PVR_ER
 PVR_ERROR UpdateTimer(const PVR_TIMER &timer) { return PVR_ERROR_NOT_IMPLEMENTED; }
 void DemuxAbort(void) {}
 DemuxPacket* DemuxRead(void) { return NULL; }
-unsigned int GetChannelSwitchDelay(void) { return 0; }
 void PauseStream(bool bPaused) {}
 bool SeekTime(double,bool,double*) { return false; }
 void SetSpeed(int) {};
@@ -360,4 +352,5 @@ bool IsRealTimeStream(void) { return true; }
 PVR_ERROR SetEPGTimeFrame(int) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR GetDescrambleInfo(PVR_DESCRAMBLE_INFO*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR SetRecordingLifetime(const PVR_RECORDING*) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR GetStreamTimes(PVR_STREAM_TIMES *times) { return PVR_ERROR_NOT_IMPLEMENTED; }
 }


### PR DESCRIPTION
Remove SwitchChannel(), GetChannelSwitchDelay(). Add GetStreamTimes() unused API, implement GetLiveStreamURL