### PR TITLE
Typo in constructor

### DIFF
--- a/src/HDHomeRunTuners.h
+++ b/src/HDHomeRunTuners.h
@@ -58,7 +58,7 @@ public:
 	{
 	public:
 		AutoLock(HDHomeRunTuners* p) : m_p(p) { m_p->Lock(); }
-		AutoLock(HDHomeRunTuners& p) : m_p(&p) { m_p->Unlock(); }
+		AutoLock(HDHomeRunTuners& p) : m_p(&p) { m_p->Lock(); }
 		~AutoLock() { m_p->Unlock(); }
 	protected:
 		HDHomeRunTuners* m_p;


### PR DESCRIPTION
Just correcting typo as brought up by Matthew Lundberg. I havent looked to see if this constructor is used or not, so it may warrant removal entirely.