### PR TITLE
Update to PVR API 5.6.0

### DIFF
--- a/pvr.hdhomerun/addon.xml.in
+++ b/pvr.hdhomerun/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hdhomerun"
-  version="3.1.2"
+  version="3.1.3"
   name="PVR HDHomeRun Client"
   provider-name="Zoltan Csizmadia (zcsizmadia@gmail.com)">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hdhomerun/changelog.txt
+++ b/pvr.hdhomerun/changelog.txt
@@ -1,3 +1,9 @@
+v3.1.3
+- Update to PVR API 5.6.0 dependency
+- Replace GetLiveStreamURL() with new API GetChannelStreamProperties()
+- Stub new unused API GetRecordingStreamProperties()
+- Fix channel change not working
+
 v3.1.2
 - Replace CStdString with std::string
 

--- a/src/HDHomeRunTuners.cpp
+++ b/src/HDHomeRunTuners.cpp
@@ -424,7 +424,7 @@ PVR_ERROR HDHomeRunTuners::PvrGetChannelGroupMembers(ADDON_HANDLE handle, const 
   return PVR_ERROR_NO_ERROR;
 }
 
-std::string HDHomeRunTuners::_GetLiveStreamURL(const PVR_CHANNEL &channel) 
+std::string HDHomeRunTuners::_GetChannelStreamURL(int iUniqueId) 
 {  
     Json::Value::ArrayIndex nIndex;
 
@@ -436,7 +436,7 @@ std::string HDHomeRunTuners::_GetLiveStreamURL(const PVR_CHANNEL &channel)
         {
             const Json::Value& jsonChannel = iterTuner->LineUp[nIndex];
 		
-            if (jsonChannel["_UID"].asUInt() == channel.iUniqueId)
+            if (jsonChannel["_UID"].asUInt() == iUniqueId)
             {
                 std::string url = jsonChannel["URL"].asString();
                 return url;

--- a/src/HDHomeRunTuners.h
+++ b/src/HDHomeRunTuners.h
@@ -76,7 +76,7 @@ public:
 	int PvrGetChannelGroupsAmount(void);
 	PVR_ERROR PvrGetChannelGroups(ADDON_HANDLE handle, bool bRadio);
 	PVR_ERROR PvrGetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &group);
-	std::string _GetLiveStreamURL(const PVR_CHANNEL &channel);
+	std::string _GetChannelStreamURL(int iUniqueId);
 	
 protected:
 	unsigned int PvrCalculateUniqueId(const String& str);

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -300,12 +300,20 @@ bool CanSeekStream(void)
 { 
   return true; 
 }
-  
-const char * GetLiveStreamURL(const PVR_CHANNEL &channel) 
-{ 
-  static std::string urlreturn = g.Tuners->_GetLiveStreamURL(channel);
-  return urlreturn.c_str();
-}
+
+PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL* channel, PVR_NAMED_VALUE* properties, unsigned int* iPropertiesCount)
+{
+    std::string strUrl = g.Tuners->_GetChannelStreamURL(channel->iUniqueId);
+    if (strUrl.empty()) {
+      return PVR_ERROR_FAILED;
+    }
+    strncpy(properties[0].strName, PVR_STREAM_PROPERTY_STREAMURL, sizeof(properties[0].strName));
+    strncpy(properties[0].strValue, strUrl.c_str(), sizeof(properties[0].strValue));
+    
+    *iPropertiesCount = 1;
+    
+	return PVR_ERROR_NO_ERROR;
+} 
   
 /* UNUSED API FUNCTIONS */
 PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook, const PVR_MENUHOOK_DATA &item) { return PVR_ERROR_NOT_IMPLEMENTED; }
@@ -358,4 +366,5 @@ PVR_ERROR SetEPGTimeFrame(int) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR GetDescrambleInfo(PVR_DESCRAMBLE_INFO*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR SetRecordingLifetime(const PVR_RECORDING*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR GetStreamTimes(PVR_STREAM_TIMES *times) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR GetRecordingStreamProperties(const PVR_RECORDING* recording, PVR_NAMED_VALUE* properties, unsigned int* iPropertiesCount) { return PVR_ERROR_NOT_IMPLEMENTED; }
 }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -307,8 +307,8 @@ PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL* channel, PVR_NAMED_VALUE
   if (strUrl.empty()) {
     return PVR_ERROR_FAILED;
   }
-  strncpy(properties[0].strName, PVR_STREAM_PROPERTY_STREAMURL, sizeof(properties[0].strName));
-  strncpy(properties[0].strValue, strUrl.c_str(), sizeof(properties[0].strValue));
+  strncpy(properties[0].strName, PVR_STREAM_PROPERTY_STREAMURL, sizeof(properties[0].strName) - 1);
+  strncpy(properties[0].strValue, strUrl.c_str(), sizeof(properties[0].strValue) - 1);
 
   *iPropertiesCount = 1;
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -303,16 +303,16 @@ bool CanSeekStream(void)
 
 PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL* channel, PVR_NAMED_VALUE* properties, unsigned int* iPropertiesCount)
 {
-    std::string strUrl = g.Tuners->_GetChannelStreamURL(channel->iUniqueId);
-    if (strUrl.empty()) {
-      return PVR_ERROR_FAILED;
-    }
-    strncpy(properties[0].strName, PVR_STREAM_PROPERTY_STREAMURL, sizeof(properties[0].strName));
-    strncpy(properties[0].strValue, strUrl.c_str(), sizeof(properties[0].strValue));
-    
-    *iPropertiesCount = 1;
-    
-	return PVR_ERROR_NO_ERROR;
+  std::string strUrl = g.Tuners->_GetChannelStreamURL(channel->iUniqueId);
+  if (strUrl.empty()) {
+    return PVR_ERROR_FAILED;
+  }
+  strncpy(properties[0].strName, PVR_STREAM_PROPERTY_STREAMURL, sizeof(properties[0].strName));
+  strncpy(properties[0].strValue, strUrl.c_str(), sizeof(properties[0].strValue));
+
+  *iPropertiesCount = 1;
+
+  return PVR_ERROR_NO_ERROR;
 } 
   
 /* UNUSED API FUNCTIONS */


### PR DESCRIPTION
Update to PVR API 5.6.0 as  per the following commit
https://github.com/xbmc/xbmc/pull/12660
May want to hold off on merge until the above commit is finalised. Have run time tested on MacOS