### PR TITLE
Use .tar.gz instead off commit number to get libhdhomerun

### DIFF
--- a/depends/common/hdhomerun/hdhomerun.txt
+++ b/depends/common/hdhomerun/hdhomerun.txt
@@ -1,1 +1,1 @@
-hdhomerun https://github.com/Silicondust/libhdhomerun 0d3b72c1ccf1502a73c7f413e7d3382d9ee732c6
+hdhomerun https://github.com/Silicondust/libhdhomerun/archive/0d3b72c1ccf1502a73c7f413e7d3382d9ee732c6.tar.gz


### PR DESCRIPTION
The Kodi cmake engine checks out only depth=1, so if the commit number is not the master, clone/checkout will fail... I think :)

Hash is not added, since the other dependencies do not specify it either (e.g. jsoncpp)