### PR TITLE
update jsoncpp to more recent build

### DIFF
--- a/depends/common/jsoncpp/jsoncpp.txt
+++ b/depends/common/jsoncpp/jsoncpp.txt
@@ -1,1 +1,1 @@
-jsoncpp http://mirrors.kodi.tv/build-deps/sources/jsoncpp-src-0.5.0.tar.gz
+jsoncpp https://github.com/open-source-parsers/jsoncpp/archive/0.10.6.tar.gz


### PR DESCRIPTION
various fixes over the ~2 years between the previous build 0.5.0 and the latest
0.10.6. runtime tested on mac os with no apparent defects