### PR TITLE
multiple tuner support

### DIFF
--- a/pvr.hdhomerun/addon.xml.in
+++ b/pvr.hdhomerun/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hdhomerun"
-  version="3.4.3"
+  version="3.5.0"
   name="PVR HDHomeRun Client"
   provider-name="Zoltan Csizmadia (zcsizmadia@gmail.com)">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hdhomerun/changelog.txt
+++ b/pvr.hdhomerun/changelog.txt
@@ -1,3 +1,6 @@
+v3.5.0
+- Allow opening stream when multiple tuners are available
+
 v3.4.1
 - Update to PVR API v5.10.1
 

--- a/src/HDHomeRunTuners.cpp
+++ b/src/HDHomeRunTuners.cpp
@@ -32,6 +32,7 @@
 #include <string>
 #include <vector>
 
+#include <libXBMC_addon.h>
 #include <p8-platform/util/StringUtils.h>
 
 #include "client.h"
@@ -220,22 +221,20 @@ bool HDHomeRunTuners::Update(int nMode)
             }
 
             jsonChannel["_Hide"] = bHide;
-            jsonChannel["_ChannelNumber"] = 0;
-            jsonChannel["_SubChannelNumber"] = 0;
+
+            int nChannel = 0, nSubChannel = 0;
+            if (sscanf(jsonChannel["GuideNumber"].asString().c_str(), "%d.%d", &nChannel, &nSubChannel) != 2)
+            {
+              nSubChannel = 0;
+              if (sscanf(jsonChannel["GuideNumber"].asString().c_str(), "%d", &nChannel) != 1)
+                nChannel = nChannelNumber;
+            }
+            jsonChannel["_ChannelNumber"] = nChannel;
+            jsonChannel["_SubChannelNumber"] = nSubChannel;
 
             if (!bHide)
             {
-              int nChannel = 0, nSubChannel = 0;
-              if (sscanf(jsonChannel["GuideNumber"].asString().c_str(), "%d.%d", &nChannel, &nSubChannel) != 2)
-              {
-                nSubChannel = 0;
-                if (sscanf(jsonChannel["GuideNumber"].asString().c_str(), "%d", &nChannel) != 1)
-                  nChannel = nChannelNumber;
-              }
-              jsonChannel["_ChannelNumber"] = nChannel;
-              jsonChannel["_SubChannelNumber"] = nSubChannel;
               guideNumberSet.insert(jsonChannel["GuideNumber"].asString());
-
               nChannelNumber++;
             }
           }
@@ -408,48 +407,62 @@ PVR_ERROR HDHomeRunTuners::PvrGetChannelGroupMembers(ADDON_HANDLE handle, const 
   return PVR_ERROR_NO_ERROR;
 }
 
-std::string HDHomeRunTuners::_GetChannelStreamURL(const PVR_CHANNEL* channel)
+// Function to return stream url from any available device.
+// Potential issue: Still possible race condition between test and player start. Without
+//        using libhdhomerun and actively managing tuner locks and using *livestream functions
+//        this race condition cannot be worked around as i see it.
+// ToDo: Potentially implement preferred tuner. At the moment as long as the tuner can
+//       show the channel requested, it will test in an unknown* order
+//       *unknown = device discovery order, which is not guaranteed to be the same from
+//                  startup to startup
+std::string HDHomeRunTuners::GetChannelStreamURL(const PVR_CHANNEL* channel)
 {
   AutoLock l(this);
 
   for (const auto& iterTuner : m_Tuners)
+  {
     for (const auto& jsonChannel : iterTuner.LineUp)
     {
-      if (jsonChannel["_UID"].asUInt() == channel->iUniqueId)
+      if (jsonChannel["_UID"].asUInt() == channel->iUniqueId ||
+           (channel->iChannelNumber == jsonChannel["_ChannelNumber"].asUInt() &&
+            channel->iSubChannelNumber == jsonChannel["_SubChannelNumber"].asUInt() &&
+            strcmp(channel->strChannelName, jsonChannel["_ChannelName"].asString().c_str()) == 0))
       {
-        if (CheckTunerAvailable(jsonChannel["URL"].asString()))
-          return jsonChannel["URL"].asString();
-        KODI_LOG(ADDON::LOG_DEBUG, "Tuner ID: %d URL Unavailable: %s", channel->iUniqueId, jsonChannel["URL"].asString().c_str());
-      }
-      else if (channel->iChannelNumber == jsonChannel["_ChannelNumber"].asUInt() &&
-               channel->iSubChannelNumber == jsonChannel["_SubChannelNumber"].asUInt() &&
-               strcmp(channel->strChannelName, jsonChannel["_ChannelName"].asString().c_str()) == 0)
-      {
-        if (CheckTunerAvailable(jsonChannel["URL"].asString()))
-          return jsonChannel["URL"].asString();
-        KODI_LOG(ADDON::LOG_DEBUG, "Tuner ID: %d URL Unavailable: %s", channel->iUniqueId, jsonChannel["URL"].asString().c_str());
+        void* fileHandle = g.XBMC->CURLCreate(jsonChannel["URL"].asString().c_str());
+
+        if (fileHandle != nullptr)
+        {
+          g.XBMC->CURLAddOption(fileHandle, XFILE::CURL_OPTION_PROTOCOL , "failonerror", "false");
+          int returnCode = -1;
+
+          if (g.XBMC->CURLOpen(fileHandle, XFILE::READ_NO_CACHE))
+          {
+            std::string proto = g.XBMC->GetFilePropertyValue(fileHandle, XFILE::FILE_PROPERTY_RESPONSE_PROTOCOL, "");
+            std::string::size_type posResponseCode = proto.find(' ');
+            if (posResponseCode != std::string::npos)
+              returnCode = atoi(proto.c_str() + (posResponseCode + 1));
+          }
+          g.XBMC->CloseFile(fileHandle);
+
+          if (returnCode <= 400)
+          {
+            return jsonChannel["URL"].asString();
+          }
+          else if (returnCode == 403)
+          {
+            KODI_LOG(ADDON::LOG_DEBUG, "Tuner ID: %d URL Unavailable: %s, Error Code: %d, All tuners in use on device", channel->iUniqueId, jsonChannel["URL"].asString().c_str(), returnCode);
+          }
+          else
+          {
+            // ToDo: Not an oversubscription error, implement a count against specific tuners. If > x non 403 failures, blacklist tuner??
+            //       potentially flag date/time of last failure, move tuner to blacklist, retry blacklist device y hours after last failure (24?)
+            KODI_LOG(ADDON::LOG_DEBUG, "Tuner ID: %d URL Unavailable: %s, Error Code: %d", channel->iUniqueId, jsonChannel["URL"].asString().c_str(), returnCode);
+          }
+        }
       }
     }
+  }
 
+  KODI_LOG(ADDON::LOG_DEBUG, "No Tuners available");
   return "";
-}
-
-// With this approach, there is potential that between Videoplayer opening the stream and
-// the result of this function, that the tuner is locked by another.
-// Unable to find exact status code using XBMC->CURLOpen, as this fails with any status
-// >= 400, and only shows returns bool saying failed.
-bool HDHomeRunTuners::CheckTunerAvailable(const std::string& url)
-{
-  void* fileHandle = g.XBMC->CURLCreate(url.c_str());
-
-  if (fileHandle == nullptr)
-    return false;
-
-  // 503 error spits out here
-  // GetFilePropertyValue does not work as the CURLOpen has failed
-  if (!g.XBMC->CURLOpen(fileHandle, XFILE::READ_NO_CACHE))
-    return false;
-
-  g.XBMC->CloseFile(fileHandle);
-  return true;
 }

--- a/src/HDHomeRunTuners.h
+++ b/src/HDHomeRunTuners.h
@@ -75,11 +75,10 @@ public:
   int PvrGetChannelGroupsAmount(void);
   PVR_ERROR PvrGetChannelGroups(ADDON_HANDLE handle, bool bRadio);
   PVR_ERROR PvrGetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &group);
-  std::string _GetChannelStreamURL(const PVR_CHANNEL* channel);
+  std::string GetChannelStreamURL(const PVR_CHANNEL* channel);
 
 private:
   unsigned int PvrCalculateUniqueId(const std::string& str);
-  bool CheckTunerAvailable(const std::string& url);
   std::vector<Tuner> m_Tuners;
   P8PLATFORM::CMutex m_Lock;
 };

--- a/src/HDHomeRunTuners.h
+++ b/src/HDHomeRunTuners.h
@@ -75,10 +75,11 @@ public:
   int PvrGetChannelGroupsAmount(void);
   PVR_ERROR PvrGetChannelGroups(ADDON_HANDLE handle, bool bRadio);
   PVR_ERROR PvrGetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &group);
-  std::string _GetChannelStreamURL(int iUniqueId);
+  std::string _GetChannelStreamURL(const PVR_CHANNEL* channel);
 
 private:
   unsigned int PvrCalculateUniqueId(const std::string& str);
+  bool CheckTunerAvailable(const std::string& url);
   std::vector<Tuner> m_Tuners;
   P8PLATFORM::CMutex m_Lock;
 };

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -298,7 +298,7 @@ PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL* channel, PVR_NAMED_VALUE
   if (*iPropertiesCount < 2)
     return PVR_ERROR_INVALID_PARAMETERS;
 
-  std::string strUrl = g.Tuners->_GetChannelStreamURL(channel);
+  std::string strUrl = g.Tuners->GetChannelStreamURL(channel);
   if (strUrl.empty())
     return PVR_ERROR_FAILED;
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -298,14 +298,18 @@ PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL* channel, PVR_NAMED_VALUE
   if (*iPropertiesCount < 2)
     return PVR_ERROR_INVALID_PARAMETERS;
 
-  std::string strUrl = g.Tuners->_GetChannelStreamURL(channel->iUniqueId);
+  std::string strUrl = g.Tuners->_GetChannelStreamURL(channel);
   if (strUrl.empty())
     return PVR_ERROR_FAILED;
 
   strncpy(properties[0].strName, PVR_STREAM_PROPERTY_STREAMURL, sizeof(properties[0].strName) - 1);
+  properties[0].strName[sizeof(properties[0].strName) - 1] = '\0';
   strncpy(properties[0].strValue, strUrl.c_str(), sizeof(properties[0].strValue) - 1);
+  properties[0].strValue[sizeof(properties[0].strValue) - 1] = '\0';
   strncpy(properties[1].strName, PVR_STREAM_PROPERTY_ISREALTIMESTREAM, sizeof(properties[1].strName) - 1);
+  properties[1].strName[sizeof(properties[1].strName) - 1] = '\0';
   strncpy(properties[1].strValue, "true", sizeof(properties[1].strValue) - 1);
+  properties[1].strValue[sizeof(properties[1].strValue) - 1] = '\0';
 
   *iPropertiesCount = 2;
 


### PR DESCRIPTION
How:
CheckTunerAvailable() does a simple CURLOpen, and will fail if a http status code
of >= 400 is returned when connecting. HDHomerun returns a 503 status code when no tuners available. This will then allow _GetChannelStreamURL() to iterate through other tuners to return another url from a different tuner. 

Dev Details:
We are not able to find the exact status code to check for a 503 using kodi's CURLOpen provided to addons, as if anything >= 400 is detected, the call fails, and the new GetFilePropertyValue() isnt able to be run with this state. Ive gone down the route of using curl/curl.h to manage status in another branch (https://github.com/fuzzard/pvr.hdhomerun/tree/openlivestream), but build issues for appveyor (building curl on win automatically, without building for all platforms (linux/mac os not needing generally) have been stumping me for a couple of days, and im going to leave that as is for now. I hate cmake, but i digress.

Issues: Using the current codebase, the most glaring issue with this is that between the time of the CheckTunerAvailable method call and the return to GetChannelStreamProperties(), there is potential for change of status (tuner no longer available, failed tuner now available). For now, i think its a viable option for users with multiple tuners.

Discussion:
To implement this in the best case scenario that i can see, we would need to return to implementing our own Open/Read/CloseLivestream functions, and use the libhdhomerun hdhomerun_device_tuner_lockkey_request and release to handle our own locking. I've been fiddling with a branch that goes down this path, but havent fleshed it all out yet. 
Interested in comments about traveling down this path to support multiple tuners better. My own personal thoughts are that it would be interesting from my dev point of view, but i dont have multiple tuners, so the testing would be tricky, and i dont know of any users who would be willing to guinea pig for me.
Is a close enough is good enough approach (This PR) good enough for most users, and therefore everything else is pointless?