### PR TITLE
cleanup objects on failure

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -109,8 +109,12 @@ ADDON_STATUS ADDON_Create(void* hdl, void* props)
 
   g.Tuners = new HDHomeRunTuners;
   if (g.Tuners == NULL)
-      return ADDON_STATUS_PERMANENT_FAILURE;
-  
+  {
+    SAFE_DELETE(g.PVR);
+    SAFE_DELETE(g.XBMC);
+    return ADDON_STATUS_PERMANENT_FAILURE;
+  }
+
   ADDON_ReadSettings();
 
   if (g.Tuners)


### PR DESCRIPTION
as these objects were created, and we are failing, we should really clean them up first. 