### PR TITLE
Code Cleanup

### DIFF
--- a/pvr.hdhomerun/addon.xml.in
+++ b/pvr.hdhomerun/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hdhomerun"
-  version="3.1.7"
+  version="3.1.8"
   name="PVR HDHomeRun Client"
   provider-name="Zoltan Csizmadia (zcsizmadia@gmail.com)">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hdhomerun/changelog.txt
+++ b/pvr.hdhomerun/changelog.txt
@@ -1,3 +1,8 @@
+v3.1.8
+- Whitespace changes (tabs to spaces to make all files uniform)
+- jsoncpp 0.10.6 Update
+- code cleanup
+
 v3.1.4
 - Update to PVR API 5.7.0
 - Stub IsEPGTagPlayable as not implemented

--- a/src/HDHomeRunTuners.cpp
+++ b/src/HDHomeRunTuners.cpp
@@ -276,7 +276,6 @@ int HDHomeRunTuners::PvrGetChannelsAmount()
 
 PVR_ERROR HDHomeRunTuners::PvrGetChannels(ADDON_HANDLE handle, bool bRadio)
 {
-  PVR_CHANNEL pvrChannel;
   Json::Value::ArrayIndex nIndex;
 
   if (bRadio)
@@ -292,7 +291,7 @@ PVR_ERROR HDHomeRunTuners::PvrGetChannels(ADDON_HANDLE handle, bool bRadio)
       if (jsonChannel["_Hide"].asBool())
         continue;
 
-      memset(&pvrChannel, 0, sizeof(pvrChannel));
+      PVR_CHANNEL pvrChannel = { 0 };
 
       pvrChannel.iUniqueId = jsonChannel["_UID"].asUInt();
       pvrChannel.iChannelNumber = jsonChannel["_ChannelNumber"].asUInt();
@@ -332,12 +331,11 @@ PVR_ERROR HDHomeRunTuners::PvrGetEPGForChannel(ADDON_HANDLE handle, const PVR_CH
       for (nGuideIndex = 0; nGuideIndex < jsonGuide.size(); nGuideIndex++)
       {
         const Json::Value& jsonGuideItem = jsonGuide[nGuideIndex];
-        EPG_TAG tag;
 
         if ((time_t)jsonGuideItem["EndTime"].asUInt() <= iStart || iEnd < (time_t)jsonGuideItem["StartTime"].asUInt())
           continue;
 
-        memset(&tag, 0, sizeof(tag));
+        EPG_TAG tag = { 0 };
 
         String
           strTitle(jsonGuideItem["Title"].asString()),
@@ -371,12 +369,10 @@ int HDHomeRunTuners::PvrGetChannelGroupsAmount()
 
 PVR_ERROR HDHomeRunTuners::PvrGetChannelGroups(ADDON_HANDLE handle, bool bRadio)
 {
-  PVR_CHANNEL_GROUP channelGroup;
-
   if (bRadio)
     return PVR_ERROR_NO_ERROR;
 
-  memset(&channelGroup, 0, sizeof(channelGroup));
+  PVR_CHANNEL_GROUP channelGroup = { 0 };
 
   channelGroup.iPosition = 1;
   PVR_STRCPY(channelGroup.strGroupName, g_strGroupFavoriteChannels.c_str());
@@ -410,9 +406,7 @@ PVR_ERROR HDHomeRunTuners::PvrGetChannelGroupMembers(ADDON_HANDLE handle, const 
         (strcmp(g_strGroupSDChannels.c_str(), group.strGroupName) == 0 && jsonChannel["HD"].asBool()))
         continue;
 
-      PVR_CHANNEL_GROUP_MEMBER channelGroupMember;
-
-      memset(&channelGroupMember, 0, sizeof(channelGroupMember));
+      PVR_CHANNEL_GROUP_MEMBER channelGroupMember = { 0 };
 
       PVR_STRCPY(channelGroupMember.strGroupName, group.strGroupName);
       channelGroupMember.iChannelUniqueId = jsonChannel["_UID"].asUInt();

--- a/src/HDHomeRunTuners.cpp
+++ b/src/HDHomeRunTuners.cpp
@@ -58,17 +58,17 @@ bool HDHomeRunTuners::Update(int nMode)
   // Discover
   //
 
-  nTunerCount = hdhomerun_discover_find_devices_custom_v2(0, HDHOMERUN_DEVICE_TYPE_TUNER, HDHOMERUN_DEVICE_ID_WILDCARD, foundDevices, 16);
-
-  KODI_LOG(LOG_DEBUG, "Found %d HDHomeRun tuners", nTunerCount);
-
   AutoLock l(this);
 
-  if (nMode & UpdateDiscover)
-  m_Tuners.clear();
+  nTunerCount = hdhomerun_discover_find_devices_custom_v2(0, HDHOMERUN_DEVICE_TYPE_TUNER, HDHOMERUN_DEVICE_ID_WILDCARD, foundDevices, 16);
 
   if (nTunerCount <= 0)
     return false;
+
+  KODI_LOG(LOG_DEBUG, "Found %d HDHomeRun tuners", nTunerCount);
+
+  if (nMode & UpdateDiscover)
+    m_Tuners.clear();
 
   for (nTunerIndex = 0; nTunerIndex < nTunerCount; nTunerIndex++)
   {

--- a/src/HDHomeRunTuners.h
+++ b/src/HDHomeRunTuners.h
@@ -31,61 +31,61 @@
 class HDHomeRunTuners
 {
 public:
-	enum
-	{
-		UpdateDiscover = 1,
-		UpdateLineUp = 2,
-		UpdateGuide = 4
-	};
+  enum
+  {
+    UpdateDiscover = 1,
+    UpdateLineUp = 2,
+    UpdateGuide = 4
+  };
 
 public:
-	struct Tuner
-	{
-		Tuner()
-		{
-			memset(&Device, 0, sizeof(Device));
-		}
+  struct Tuner
+  {
+    Tuner()
+    {
+      memset(&Device, 0, sizeof(Device));
+  }
 
-		hdhomerun_discover_device_t Device;
+    hdhomerun_discover_device_t Device;
 
-		Json::Value LineUp;
-		Json::Value Guide;
-	};
+    Json::Value LineUp;
+    Json::Value Guide;
+  };
 
-	typedef std::vector<Tuner> Tuners;
+  typedef std::vector<Tuner> Tuners;
 
-	class AutoLock
-	{
-	public:
-		AutoLock(HDHomeRunTuners* p) : m_p(p) { m_p->Lock(); }
-		AutoLock(HDHomeRunTuners& p) : m_p(&p) { m_p->Lock(); }
-		~AutoLock() { m_p->Unlock(); }
-	protected:
-		HDHomeRunTuners* m_p;
-	};
-
-public:
-	HDHomeRunTuners();
-
-	bool Update(int nMode = UpdateDiscover | UpdateLineUp | UpdateGuide);
+  class AutoLock
+  {
+  public:
+    AutoLock(HDHomeRunTuners* p) : m_p(p) { m_p->Lock(); }
+    AutoLock(HDHomeRunTuners& p) : m_p(&p) { m_p->Lock(); }
+    ~AutoLock() { m_p->Unlock(); }
+  protected:
+    HDHomeRunTuners* m_p;
+  };
 
 public:
-	PVR_ERROR PvrGetChannels(ADDON_HANDLE handle, bool bRadio);
-	int PvrGetChannelsAmount();
-	PVR_ERROR PvrGetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL& channel, time_t iStart, time_t iEnd);
-	int PvrGetChannelGroupsAmount(void);
-	PVR_ERROR PvrGetChannelGroups(ADDON_HANDLE handle, bool bRadio);
-	PVR_ERROR PvrGetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &group);
-	std::string _GetChannelStreamURL(int iUniqueId);
-	
-protected:
-	unsigned int PvrCalculateUniqueId(const String& str);
+  HDHomeRunTuners();
+
+  bool Update(int nMode = UpdateDiscover | UpdateLineUp | UpdateGuide);
 
 public:
-	void Lock() { m_Lock.Lock(); }
-	void Unlock() { m_Lock.Unlock(); }
+  PVR_ERROR PvrGetChannels(ADDON_HANDLE handle, bool bRadio);
+  int PvrGetChannelsAmount();
+  PVR_ERROR PvrGetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL& channel, time_t iStart, time_t iEnd);
+  int PvrGetChannelGroupsAmount(void);
+  PVR_ERROR PvrGetChannelGroups(ADDON_HANDLE handle, bool bRadio);
+  PVR_ERROR PvrGetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &group);
+  std::string _GetChannelStreamURL(int iUniqueId);
 
 protected:
-	Tuners m_Tuners;
-	P8PLATFORM::CMutex m_Lock;
+  unsigned int PvrCalculateUniqueId(const String& str);
+
+public:
+  void Lock() { m_Lock.Lock(); }
+  void Unlock() { m_Lock.Unlock(); }
+
+protected:
+  Tuners m_Tuners;
+  P8PLATFORM::CMutex m_Lock;
 };

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -28,71 +28,71 @@
 #if defined(USE_DBG_CONSOLE) && defined(TARGET_WINDOWS)
 int DbgPrintf(const char* szFormat, ...)
 {
-	static bool g_bDebugConsole = false;
-	char szBuffer[4096];
-	int nLen;
-	va_list args;
-	DWORD dwWritten;
-	
-	if (!g_bDebugConsole)
-	{
-		::AllocConsole();
-		g_bDebugConsole = true;
-	}
+  static bool g_bDebugConsole = false;
+  char szBuffer[4096];
+  int nLen;
+  va_list args;
+  DWORD dwWritten;
 
-	va_start(args, szFormat);
-	nLen = vsnprintf(szBuffer, sizeof(szBuffer) - 1, szFormat, args);
-	::WriteConsole(GetStdHandle(STD_OUTPUT_HANDLE), szBuffer, nLen, &dwWritten, 0);
-	va_end(args);
+  if (!g_bDebugConsole)
+  {
+    ::AllocConsole();
+    g_bDebugConsole = true;
+  }
 
-	return nLen;
+  va_start(args, szFormat);
+  nLen = vsnprintf(szBuffer, sizeof(szBuffer) - 1, szFormat, args);
+  ::WriteConsole(GetStdHandle(STD_OUTPUT_HANDLE), szBuffer, nLen, &dwWritten, 0);
+  va_end(args);
+
+  return nLen;
 }
 #endif
 
 bool GetFileContents(const String& url, String& strContent)
 {
-	char buffer[1024];
-	void* fileHandle;
-	
-	strContent.clear();
+  char buffer[1024];
+  void* fileHandle;
 
-	fileHandle = g.XBMC->OpenFile(url.c_str(), 0);
+  strContent.clear();
 
-	if (fileHandle == NULL)
-	{
-		KODI_LOG(0, "GetFileContents: %s failed\n", url.c_str());
-		return false;
-	}
-	
-	for (;;)
-	{
-		ssize_t bytesRead = g.XBMC->ReadFile(fileHandle, buffer, sizeof(buffer));
-		if (bytesRead <= 0)
-			break;
-		strContent.append(buffer, bytesRead);
-	}
+  fileHandle = g.XBMC->OpenFile(url.c_str(), 0);
 
-	g.XBMC->CloseFile(fileHandle);
+  if (fileHandle == NULL)
+  {
+    KODI_LOG(0, "GetFileContents: %s failed\n", url.c_str());
+    return false;
+  }
 
-	return true;
+  for (;;)
+  {
+    ssize_t bytesRead = g.XBMC->ReadFile(fileHandle, buffer, sizeof(buffer));
+    if (bytesRead <= 0)
+      break;
+    strContent.append(buffer, bytesRead);
+  }
+
+  g.XBMC->CloseFile(fileHandle);
+
+  return true;
 }
 
 String EncodeURL(const String& strUrl)
 {
-	String str, strEsc;
+  String str, strEsc;
 
-	for (String::const_iterator iter = strUrl.begin(); iter != strUrl.end(); iter++)
-	{
-		char c = *iter;
+  for (String::const_iterator iter = strUrl.begin(); iter != strUrl.end(); iter++)
+  {
+    char c = *iter;
 
-		if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~')
-			str += c;
-		else
-		{
-			String strPercent = StringUtils::Format("%%%02X", (int)c);
-			str += strPercent;
-		}
-	}
+    if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~')
+      str += c;
+    else
+    {
+      String strPercent = StringUtils::Format("%%%02X", (int)c);
+      str += strPercent;
+    }
+  }
 
-	return str;
+  return str;
 }

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -33,18 +33,18 @@
 #ifdef USE_DBG_CONSOLE
 int DbgPrintf(const char* szFormat, ...);
 #else
-#define DbgPrintf(...)							do {} while(0)
+#define DbgPrintf(...)              do {} while(0)
 #endif // USE_DBG_CONSOLE
 
-#define KODI_LOG(level, ...)											\
-    do																	\
-	{																	\
-        DbgPrintf("%-10s: ", #level);									\
-        DbgPrintf(__VA_ARGS__);											\
-        DbgPrintf("\n");												\
+#define KODI_LOG(level, ...)          \
+  do                                  \
+  {                                   \
+        DbgPrintf("%-10s: ", #level); \
+        DbgPrintf(__VA_ARGS__);       \
+        DbgPrintf("\n");              \
         if (g.XBMC && (level > ADDON::LOG_DEBUG || g.Settings.bDebug))  \
-            g.XBMC->Log((ADDON::addon_log_t)level, __VA_ARGS__);		\
-	} while (0)
+            g.XBMC->Log((ADDON::addon_log_t)level, __VA_ARGS__);        \
+  } while (0)
 
 #define PVR_STRCPY(dest, source) do { strncpy(dest, source, sizeof(dest)-1); dest[sizeof(dest)-1] = '\0'; } while(0)
 #define PVR_STRCLR(dest) memset(dest, 0, sizeof(dest))

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -109,8 +109,12 @@ ADDON_STATUS ADDON_Create(void* hdl, void* props)
 
   g.Tuners = new HDHomeRunTuners;
   if (g.Tuners == NULL)
-      return ADDON_STATUS_PERMANENT_FAILURE;
-  
+  {
+    SAFE_DELETE(g.PVR);
+    SAFE_DELETE(g.XBMC);
+    return ADDON_STATUS_PERMANENT_FAILURE;
+  }
+
   ADDON_ReadSettings();
 
   if (g.Tuners)

--- a/src/client.h
+++ b/src/client.h
@@ -33,43 +33,43 @@ class HDHomeRunTuners;
 
 struct SettingsType
 {
-	SettingsType()
-	{
-		bHideProtected = true;
-		bHideDuplicateChannels = true;
-		bDebug = false;
-		bMarkNew = false;
-	}
+  SettingsType()
+  {
+    bHideProtected = true;
+    bHideDuplicateChannels = true;
+    bDebug = false;
+    bMarkNew = false;
+  }
 
-	bool bHideProtected;
-	bool bHideDuplicateChannels;
-	bool bDebug;
-	bool bMarkNew;
+  bool bHideProtected;
+  bool bHideDuplicateChannels;
+  bool bDebug;
+  bool bMarkNew;
 };
 
 struct GlobalsType
 {
-	GlobalsType()
-	{
-		bCreated = false;
-		currentStatus = ADDON_STATUS_UNKNOWN;
-		iCurrentChannelUniqueId = 0;
-		XBMC = NULL;
-		PVR = NULL;
-		Tuners = NULL;
-	}
+  GlobalsType()
+  {
+    bCreated = false;
+    currentStatus = ADDON_STATUS_UNKNOWN;
+    iCurrentChannelUniqueId = 0;
+    XBMC = NULL;
+    PVR = NULL;
+    Tuners = NULL;
+  }
 
-	bool bCreated;
-	ADDON_STATUS currentStatus;
-	unsigned int iCurrentChannelUniqueId;
-	String strUserPath;
-	String strClientPath;
-	ADDON::CHelper_libXBMC_addon* XBMC;
-	CHelper_libXBMC_pvr* PVR;
+  bool bCreated;
+  ADDON_STATUS currentStatus;
+  unsigned int iCurrentChannelUniqueId;
+  String strUserPath;
+  String strClientPath;
+  ADDON::CHelper_libXBMC_addon* XBMC;
+  CHelper_libXBMC_pvr* PVR;
 
-	HDHomeRunTuners* Tuners;
+  HDHomeRunTuners* Tuners;
 
-	SettingsType Settings;
+  SettingsType Settings;
 };
 
 extern GlobalsType g;


### PR DESCRIPTION
Just sets all files to use spaces instead of tab. The majority already uses this, so figure it all might as well match. I guess im a bit ocd, so feel free to reject. There is absolutelly NO functional changes in the whitespace fixup.

The execution change in Update() is to create the lock earlier, and exit if tuner discovery failure earlier. should have very little affect, but figure it might be a little nicer.