### PR TITLE
[RFC] Recording + Timers - [Dont Merge]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(JsonCpp REQUIRED)
 find_package(hdhomerun REQUIRED)
 
 include_directories(${kodiplatform_INCLUDE_DIRS}
+                    ${KODI_INCLUDE_DIR}/..
                     ${p8-platform_INCLUDE_DIRS}
                     ${KODI_INCLUDE_DIR}
                     ${JSONCPP_INCLUDE_DIRS}
@@ -25,10 +26,19 @@ set(DEPLIBS ${kodiplatform_LIBRARIES}
 
 set(PVRHDHOMERUN_SOURCES src/client.cpp
                          src/HDHomeRunTuners.cpp
+                         src/HDRecorder.cpp
+                         src/HDRecorderJob.cpp
+                         src/HDRecorderScheduler.cpp
+                         src/HDRecorderThread.cpp
                          src/Utils.cpp)
 
 set(PVRHDHOMERUN_HEADERS src/client.h
                          src/HDHomeRunTuners.h
+                         src/HDRecorder.h
+                         src/HDRecorderJob.h
+                         src/HDRecorderScheduler.h
+                         src/HDRecorderThread.h
+                         src/HDRecorderUtils.h
                          src/Utils.h)
 
 if(WIN32)

--- a/pvr.hdhomerun/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.hdhomerun/resources/language/resource.language.en_gb/strings.po
@@ -35,3 +35,12 @@ msgstr ""
 msgctxt "#32005"
 msgid "Mark new show"
 msgstr ""
+
+msgctxt "#32201"
+msgid "Recording Settings"
+msgstr "Recording Settings"
+
+msgctxt "#32202
+msgid "Save Recordings to Path"
+msgstr "Save Recordings to Path"
+

--- a/pvr.hdhomerun/resources/settings.xml
+++ b/pvr.hdhomerun/resources/settings.xml
@@ -9,4 +9,8 @@
     <setting id="mark_new" type="bool" label="32005" default="true" />
   </category>
 
+  <!-- Recording -->
+  <category label="32201">
+    <setting id="recpath" type="folder" label="32202" value="special://home/" />
+  </category>
 </settings>

--- a/src/HDHomeRunTuners.h
+++ b/src/HDHomeRunTuners.h
@@ -79,6 +79,7 @@ public:
   std::vector<Tuner>& GetTuners();
   PVR_ERROR GetEPGTagForChannel(EPG_TAG& tag, PVR_CHANNEL& channel, time_t startTime, time_t endTime);
   Tuner* GetChannelTuners(PVR_CHANNEL& channel);
+  PVR_ERROR PvrGetDriveSpace(long long *iTotal, long long *iUsed);
 
 private:
   unsigned int PvrCalculateUniqueId(const std::string& str);

--- a/src/HDHomeRunTuners.h
+++ b/src/HDHomeRunTuners.h
@@ -76,6 +76,9 @@ public:
   PVR_ERROR PvrGetChannelGroups(ADDON_HANDLE handle, bool bRadio);
   PVR_ERROR PvrGetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &group);
   std::string _GetChannelStreamURL(int iUniqueId);
+  std::vector<Tuner>& GetTuners();
+  PVR_ERROR GetEPGTagForChannel(EPG_TAG& tag, PVR_CHANNEL& channel, time_t startTime, time_t endTime);
+  Tuner* GetChannelTuners(PVR_CHANNEL& channel);
 
 private:
   unsigned int PvrCalculateUniqueId(const std::string& str);

--- a/src/HDRecorder.cpp
+++ b/src/HDRecorder.cpp
@@ -1,0 +1,596 @@
+/*
+ *  Copyright (C) 2017 Brent Murphy <bmurphy@bcmcs.net>
+ *  https://github.com/fuzzard/pvr.hdhomerun
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "HDRecorder.h"
+
+#include <ctime>
+#include <chrono>
+#include <map>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include <json/json.h>
+#include <p8-platform/util/util.h>
+#include <p8-platform/threads/mutex.h>
+#include <p8-platform/threads/threads.h>
+
+#include "HDHomeRunTuners.h"
+#include "HDRecorderJob.h"
+#include "HDRecorderScheduler.h"
+#include "HDRecorderThread.h"
+#include "HDRecorderUtils.h"
+#include "Utils.h"
+
+HDRecorder::HDRecorder()
+{
+  SetTriggerTimerUpdate(false);
+  r_HDRecJob = new HDRecorderJob;
+  r_HDRecScheduler = new HDRecorderScheduler(r_HDRecJob);
+}
+
+HDRecorder::~HDRecorder()
+{
+  r_HDRecScheduler->StopThread(true);
+  g.RECORDER->setLock();
+  std::map<int,PVR_REC_JOB_ENTRY> RecordJobs = r_HDRecJob->getEntryData();
+  g.RECORDER->setUnlock();
+  for (const auto& rec : RecordJobs)
+  {
+    if (rec.second.Timer.state == PVR_TIMER_STATE_RECORDING)
+    {
+      KODI_LOG(ADDON::LOG_DEBUG, "HDRecorder Shutdown - Closing Active Thread");
+      PVR_REC_JOB_ENTRY entry = rec.second;
+      HDRecorderThread* recThread = reinterpret_cast<HDRecorderThread*>(entry.ThreadPtr);
+      g.RECORDER->setLock();
+      StopRecording(rec.second);
+      g.RECORDER->setUnlock();
+
+      PVR_RECORDING_ENTRY RecordingEntry;
+      RecordingEntry.Status = PVR_RECORDING_INCOMPLETE;
+      g.RECORDER->CreateRecordingItem(rec.second, RecordingEntry);
+      g.RECORDER->setLock();
+      r_HDRecJob->updateRecEntry(RecordingEntry);
+      g.RECORDER->setUnlock();
+      g.RECORDER->SetTriggerRecordingUpdate(true);
+      // ToDo: Find a way to wait until thread is shutdown
+      std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+      if (recThread != nullptr)
+      {
+        delete recThread;
+        recThread = nullptr;
+        KODI_LOG(ADDON::LOG_DEBUG, "HDRecorder Shutdown - Thread Deleted");
+      }
+    }
+  }
+  delete r_HDRecScheduler;
+  r_HDRecScheduler = nullptr;
+  KODI_LOG(ADDON::LOG_DEBUG, "HDRecScheduler Shutdown");
+  delete r_HDRecJob; 
+  r_HDRecJob = nullptr;
+  KODI_LOG(ADDON::LOG_DEBUG, "HDRecJob Shutdown");
+}
+
+// Mutex Locks
+void HDRecorder::setLock(void)
+{
+  rec_mutex.Lock();
+}
+
+void HDRecorder::setUnlock(void)
+{
+  rec_mutex.Unlock();
+}
+
+// Recording
+bool HDRecorder::StartRecording (const PVR_REC_JOB_ENTRY &RecJobEntry)
+{
+  PVR_REC_JOB_ENTRY entry;
+  if (r_HDRecJob->getJobEntry(RecJobEntry.Timer.iClientIndex, entry))
+  {
+    KODI_LOG(ADDON::LOG_DEBUG, "Recjob found: %s", RecJobEntry.Timer.strTitle);
+    if (g.RECORDER->GetJobChannel(entry))
+    {
+      KODI_LOG(ADDON::LOG_DEBUG, "Starting recording %s", RecJobEntry.Timer.strTitle);
+      entry.Status = PVR_STREAM_START_RECORDING;
+      entry.Timer.state = PVR_TIMER_STATE_RECORDING;
+      HDRecorderThread* TPtr = new HDRecorderThread(RecJobEntry.Timer.iClientIndex, r_HDRecJob);
+      entry.ThreadPtr = TPtr;
+      if (!r_HDRecJob->updateJobEntry(entry))
+        KODI_LOG(ADDON::LOG_NOTICE, "updateJobEntry failed");
+      return true;
+    }
+    else
+    {
+      KODI_LOG(ADDON::LOG_DEBUG, "Getjobchannel failed: %s", RecJobEntry.Timer.strTitle);
+      entry.Status = PVR_STREAM_STOPPED;
+      entry.Timer.state = PVR_TIMER_STATE_ERROR;
+      if (entry.ThreadPtr != nullptr)
+      {
+        delete reinterpret_cast<HDRecorderThread*>(entry.ThreadPtr);
+        entry.ThreadPtr = nullptr;
+      }
+
+      r_HDRecJob->updateJobEntry(entry);
+    }
+  }
+  return false;
+}
+
+void HDRecorder::StopRecording (const PVR_REC_JOB_ENTRY &RecJobEntry)
+{
+  PVR_REC_JOB_ENTRY entry = RecJobEntry;
+  if (entry.Timer.state!=PVR_TIMER_STATE_NEW)
+  {
+    KODI_LOG(ADDON::LOG_DEBUG, "Stopping recording %s", entry.Timer.strTitle);
+    entry.Status = PVR_STREAM_IS_STOPPING;
+    r_HDRecJob->updateJobEntry(entry);
+  }
+}
+
+// rework completely
+// add second argument to populate tuner channel
+bool HDRecorder::GetJobChannel(PVR_REC_JOB_ENTRY rec)
+{
+/*  HDHomeRunTuners::Tuners& tuners = g.Tuners->GetTuners();
+  HDHomeRunTuners::Tuner* pTuner;
+  int nIndex;
+
+//  tuners = g.Tuners->GetTuners();
+  for (HDHomeRunTuners::Tuners::iterator iter = tuners.begin(); iter != tuners.end(); iter++)
+  {
+    pTuner = &*iter;
+    for (nIndex = 0; nIndex < pTuner->LineUp.size(); nIndex++)
+    {
+      if(iter->LineUp[nIndex]["_UID"].asUInt() == rec.iChannelUid)
+        return true;
+    }
+  }
+
+  return false;
+*/
+return true;
+}
+
+// Timers
+PVR_ERROR HDRecorder::GetTimers(ADDON_HANDLE handle)
+{
+  g.RECORDER->setLock();
+  std::map<int,PVR_REC_JOB_ENTRY> RecordJobs = r_HDRecJob->getEntryData();
+  for (const auto& rec : RecordJobs)
+  {
+    if (g.RECORDER->GetJobChannel(rec.second))
+    {
+      r_HDRecJob->updateJobEntry(rec.second);
+      g.PVR->TransferTimerEntry(handle, &rec.second.Timer);
+    }
+  }
+  g.RECORDER->setUnlock();
+  return PVR_ERROR_NO_ERROR;
+}
+
+int HDRecorder::GetTimersAmount(void)
+{
+  g.RECORDER->setLock();
+  std::map<int,PVR_REC_JOB_ENTRY> RecordJobs = r_HDRecJob->getEntryData();
+  g.RECORDER->setUnlock();
+  return RecordJobs.size();
+}
+
+PVR_ERROR HDRecorder::UpdateTimer(const PVR_TIMER &timer)
+{
+  PVR_TIMER myTimer = timer;
+  PVR_REC_JOB_ENTRY entry;
+  g.RECORDER->setLock();
+  if (r_HDRecJob->getJobEntry(timer.iClientIndex, entry))
+  {
+    if (entry.Timer.state == PVR_TIMER_STATE_RECORDING &&
+        (entry.Status == PVR_STREAM_IS_RECORDING || entry.Status == PVR_STREAM_START_RECORDING || entry.Status == PVR_STREAM_IS_STOPPING))
+    {
+      //Job is active
+      if (timer.state == PVR_TIMER_STATE_CANCELLED)
+      {
+        //stop recording
+        StopRecording(entry);
+        PVR_RECORDING_ENTRY RecordingEntry;
+        RecordingEntry.Status = PVR_RECORDING_INCOMPLETE;
+        g.RECORDER->CreateRecordingItem(entry, RecordingEntry);
+        r_HDRecJob->updateRecEntry(RecordingEntry);
+        g.RECORDER->SetTriggerRecordingUpdate(true);
+      }
+      else
+      {
+        myTimer.state = entry.Timer.state;
+      }
+    }
+    entry.Timer = myTimer;
+    r_HDRecJob->updateJobEntry(entry);
+    g.RECORDER->SetTriggerTimerUpdate(true);
+    g.RECORDER->setUnlock();
+    return PVR_ERROR_NO_ERROR;
+  }
+  g.RECORDER->setUnlock();
+  return PVR_ERROR_FAILED;
+}
+
+PVR_ERROR HDRecorder::DeleteTimer(const PVR_TIMER &timer, bool bForceDelete)
+{
+  PVR_REC_JOB_ENTRY entry;
+  g.RECORDER->setLock();
+  if (r_HDRecJob->getJobEntry(timer.iClientIndex, entry))
+  {
+    StopRecording(entry);
+    g.RECORDER->SetTriggerTimerUpdate(true);
+    g.RECORDER->setUnlock();
+    return PVR_ERROR_NO_ERROR;
+  }
+  g.RECORDER->setUnlock();
+  return PVR_ERROR_FAILED;
+}
+
+PVR_ERROR HDRecorder::AddTimer (const PVR_TIMER &timer)
+{
+  if (g.Settings.strRecPath.length() == 0)
+  {
+    KODI_LOG(ADDON::LOG_ERROR, "Recording folder is not set. Please change addon configuration.");
+    return PVR_ERROR_FAILED;
+  }
+
+  //Bad start time and end time  
+  if (timer.startTime >= timer.endTime)
+    return PVR_ERROR_FAILED;
+
+  //Set start time for Job
+  //Correct start time if needed
+  time_t startTime, endTime = timer.endTime;
+  if (timer.startTime == 0 || timer.startTime < time(nullptr))
+    startTime = time(nullptr);
+  else
+    time_t startTime = timer.startTime;
+
+  //GetChannel definition
+  PVR_CHANNEL channel;
+  channel.iUniqueId = timer.iClientChannelUid;
+
+  HDHomeRunTuners::Tuner* currentChannelTuner = g.Tuners->GetChannelTuners(channel);
+  if (currentChannelTuner == nullptr)
+    return PVR_ERROR_FAILED;
+
+  Json::Value::ArrayIndex nIndex = 0;
+  int channelIndex = -1;
+  for (const auto& jsonChannel : currentChannelTuner->LineUp)
+  {
+    if (jsonChannel["_UID"].asUInt() == channel.iUniqueId)
+    {
+      channelIndex = nIndex;
+      break;
+    }
+    nIndex++;
+  }
+
+  if (channelIndex == -1)
+    return PVR_ERROR_FAILED;
+
+  g.RECORDER->setLock();
+  //Check, if job is already schduled for this time
+  std::map<int, PVR_REC_JOB_ENTRY> RecJobs = r_HDRecJob->getEntryData();
+  g.RECORDER->setUnlock();
+
+  for (const auto& rec : RecJobs)
+    if (rec.second.strChannelName == currentChannelTuner->LineUp[channelIndex]["GuideName"].asString())
+      if ((rec.second.Timer.endTime > startTime && rec.second.Timer.startTime < endTime) ||
+          (rec.second.Timer.startTime < endTime && rec.second.Timer.endTime > startTime) ||
+          (rec.second.Timer.startTime < startTime && rec.second.Timer.endTime > endTime) ||
+          (rec.second.Timer.startTime > startTime && rec.second.Timer.endTime < endTime))
+      {
+        //Similar recording already scheduled
+        if ((rec.second.Timer.state == PVR_TIMER_STATE_SCHEDULED || (rec.second.Timer.state == PVR_TIMER_STATE_RECORDING)) &&
+            (rec.second.Status == PVR_STREAM_IS_RECORDING || rec.second.Status == PVR_STREAM_START_RECORDING))
+        {
+          //Send message to refresh timers
+          KODI_LOG(ADDON::LOG_NOTICE, "Timer already exists");
+          return PVR_ERROR_ALREADY_PRESENT;
+        }
+      }
+
+  //Prepare new entry
+  KODI_LOG(ADDON::LOG_DEBUG, "Creating Timer");
+  PVR_REC_JOB_ENTRY recJobEntry;
+  recJobEntry.Timer = timer;
+  recJobEntry.Timer.iClientIndex = g.RECORDER->GetTimersAmount() + 1;
+
+// ToDo: check through guide and grab name. Possibly set timer name to be of structure
+//       showname - Episode Numbering
+//       may need a function to create the string, as episode numbering is not guaranteed
+//       check for legal characters and strip
+//  strncpy(recJobEntry.Timer.strTitle, jsonRecJob["Title"].asString().c_str(), sizeof(RecJobEntry.Timer.strTitle) - 1);
+//  recJobEntry.Timer.iClientChannelUid = PVR_CHANNEL_INVALID_UID;
+  recJobEntry.Timer.startTime = startTime;
+  recJobEntry.Timer.endTime = endTime;
+  recJobEntry.strChannelName = currentChannelTuner->LineUp[channelIndex]["GuideName"].asString();
+  recJobEntry.strGuideNumber = currentChannelTuner->LineUp[channelIndex]["GuideNumber"].asString();
+
+  g.RECORDER->setLock();
+  r_HDRecJob->addJobEntry(recJobEntry);
+
+  if (startTime <= time(nullptr))
+  {
+    recJobEntry.Status = PVR_STREAM_IS_RECORDING;
+    recJobEntry.Timer.state = PVR_TIMER_STATE_RECORDING;
+    r_HDRecJob->updateJobEntry(recJobEntry);
+    StartRecording(recJobEntry);
+    g.RECORDER->SetTriggerTimerUpdate(true);
+    KODI_LOG(ADDON::LOG_DEBUG, "Timer started, Recording started");
+  }
+  else
+  {
+    recJobEntry.Status = PVR_STREAM_NO_STREAM;
+    recJobEntry.Timer.state = PVR_TIMER_STATE_SCHEDULED;
+    r_HDRecJob->updateJobEntry(recJobEntry);
+    KODI_LOG(ADDON::LOG_DEBUG, "Timer scheduled");
+  }
+  g.RECORDER->setUnlock();
+  g.RECORDER->SetTriggerTimerUpdate(true);
+  return PVR_ERROR_NO_ERROR;
+}
+
+PVR_ERROR HDRecorder::GetTimerTypes(PVR_TIMER_TYPE types[], int* size)
+{
+
+  unsigned int TIMER_ONCE_MANUAL_ATTRIBS
+    = PVR_TIMER_TYPE_IS_MANUAL           |
+      PVR_TIMER_TYPE_SUPPORTS_CHANNELS   |
+      PVR_TIMER_TYPE_SUPPORTS_START_TIME |
+      PVR_TIMER_TYPE_SUPPORTS_END_TIME   |
+      PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE;
+
+/*  unsigned int TIMER_REPEATING_MANUAL_ATTRIBS
+    = PVR_TIMER_TYPE_IS_REPEATING                |
+      PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE     |
+      PVR_TIMER_TYPE_SUPPORTS_TITLE_EPG_MATCH    |
+      PVR_TIMER_TYPE_SUPPORTS_CHANNELS           |
+      PVR_TIMER_TYPE_SUPPORTS_START_TIME         |
+      PVR_TIMER_TYPE_SUPPORTS_START_ANYTIME      |
+      PVR_TIMER_TYPE_SUPPORTS_WEEKDAYS           |
+      PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN   |
+      PVR_TIMER_TYPE_SUPPORTS_PRIORITY           |
+      PVR_TIMER_TYPE_SUPPORTS_LIFETIME           |
+      PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS  |
+      PVR_TIMER_TYPE_SUPPORTS_ANY_CHANNEL;
+*/
+  unsigned int TIMER_ONCE_EPG_ATTRIBS
+    = PVR_TIMER_TYPE_SUPPORTS_CHANNELS          |
+      PVR_TIMER_TYPE_SUPPORTS_START_TIME        |
+      PVR_TIMER_TYPE_SUPPORTS_END_TIME          |
+      PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE |
+      PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN  |
+      PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE;
+/*
+  unsigned int TIMER_REPEATING_EPG_ATTRIBS
+    = PVR_TIMER_TYPE_IS_REPEATING                |
+      PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE     |
+      PVR_TIMER_TYPE_SUPPORTS_TITLE_EPG_MATCH    |
+      PVR_TIMER_TYPE_SUPPORTS_CHANNELS           |
+      PVR_TIMER_TYPE_SUPPORTS_START_TIME         |
+      PVR_TIMER_TYPE_SUPPORTS_START_ANYTIME      |
+      PVR_TIMER_TYPE_SUPPORTS_WEEKDAYS           |
+      PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN   |
+      PVR_TIMER_TYPE_SUPPORTS_PRIORITY           |
+      PVR_TIMER_TYPE_SUPPORTS_LIFETIME           |
+      PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS  |
+      PVR_TIMER_TYPE_SUPPORTS_ANY_CHANNEL;
+*/
+  /* Timer types definition. */
+  std::vector< std::unique_ptr<TimerType> > timerTypes;
+
+  timerTypes.emplace_back(
+    /* One-shot manual (time and channel based) */
+    std::unique_ptr<TimerType>(new TimerType(
+      /* Type id. */
+      TIMER_ONCE_MANUAL,
+      /* Attributes. */
+      TIMER_ONCE_MANUAL_ATTRIBS,
+      /* Let Kodi generate the description. */
+      "")));
+
+  timerTypes.emplace_back(
+    /* One-shot epg based */
+    std::unique_ptr<TimerType>(new TimerType(
+      /* Type id. */
+      TIMER_ONCE_EPG,
+      /* Attributes. */
+      TIMER_ONCE_EPG_ATTRIBS,
+      /* Let Kodi generate the description. */
+      "")));
+
+//  timerTypes.emplace_back(
+    /* Repeating manual (time and channel based) - timerec */
+//    std::unique_ptr<TimerType>(new TimerType(
+      /* Type id. */
+//      TIMER_REPEATING_MANUAL,
+      /* Attributes. */
+//      TIMER_REPEATING_MANUAL_ATTRIBS,
+      /* Let Kodi generate the description. */
+//      "")));
+
+//  timerTypes.emplace_back(
+    /* Repeating epg based - autorec */
+//    std::unique_ptr<TimerType>(new TimerType(
+      /* Type id. */
+//      TIMER_REPEATING_EPG,
+      /* Attributes. */
+//      TIMER_REPEATING_EPG_ATTRIBS,
+      /* Let Kodi generate the description. */
+//      "")));
+
+  /* Copy data to target array. */
+  int i = 0;
+  for (auto it = timerTypes.begin(); it != timerTypes.end(); ++it, ++i)
+    types[i] = **it;
+
+  *size = timerTypes.size();
+
+  return PVR_ERROR_NO_ERROR;
+}
+
+bool HDRecorder::GetTriggerTimerUpdate(void)
+{
+  return bTriggerTimerUpdate;
+}
+
+void HDRecorder::SetTriggerTimerUpdate(bool bTimerUpdate)
+{
+  bTriggerTimerUpdate = bTimerUpdate;
+}
+
+bool HDRecorder::GetTriggerRecordingUpdate(void)
+{
+  return bTriggerRecordingUpdate;
+}
+
+void HDRecorder::SetTriggerRecordingUpdate(bool bRecordingUpdate)
+{
+  bTriggerRecordingUpdate = bRecordingUpdate;
+}
+
+// Recordings
+PVR_ERROR HDRecorder::GetRecordings(ADDON_HANDLE handle)
+{
+  g.RECORDER->setLock();
+  std::map<int,PVR_RECORDING_ENTRY> Recordings = r_HDRecJob->getEntryData(HDRecorderJob::RecordingCache);
+  for (const auto& rec : Recordings)
+    g.PVR->TransferRecordingEntry(handle, &rec.second.Recording);
+
+  g.RECORDER->setUnlock();
+  return PVR_ERROR_NO_ERROR;
+}
+
+int HDRecorder::GetRecordingsAmount()
+{
+  g.RECORDER->setLock();
+  std::map<int,PVR_RECORDING_ENTRY> Recordings = r_HDRecJob->getEntryData(HDRecorderJob::RecordingCache);
+  g.RECORDER->setUnlock();
+  return Recordings.size();
+}
+
+PVR_ERROR HDRecorder::DeleteRecording(const PVR_RECORDING& recording)
+{
+  PVR_RECORDING_ENTRY entry;
+  g.RECORDER->setLock();
+  if (r_HDRecJob->getRecEntry(recording.strRecordingId, entry))
+  {
+    DeleteRecordingItem(entry);
+    g.RECORDER->SetTriggerRecordingUpdate(true);
+    g.RECORDER->setUnlock();
+    return PVR_ERROR_NO_ERROR;
+  }
+  g.RECORDER->setUnlock();
+  return PVR_ERROR_FAILED;
+}
+
+PVR_ERROR HDRecorder::RenameRecording(const PVR_RECORDING& RecordingEntry)
+{
+  return PVR_ERROR_NOT_IMPLEMENTED;
+}
+
+PVR_ERROR HDRecorder::SetRecordingPlayCount(const PVR_RECORDING& RecordingEntry, int count)
+{
+  PVR_RECORDING_ENTRY entry;
+  g.RECORDER->setLock();
+  if (r_HDRecJob->getRecEntry(RecordingEntry.strRecordingId, entry))
+  {
+    entry.Recording.iPlayCount = count;
+    r_HDRecJob->updateRecEntry(entry);
+    g.RECORDER->SetTriggerRecordingUpdate(true);
+    g.RECORDER->setUnlock();
+    return PVR_ERROR_NO_ERROR;
+  }
+  g.RECORDER->setUnlock();
+  return PVR_ERROR_FAILED;
+}
+
+void HDRecorder::DeleteRecordingItem (const PVR_RECORDING_ENTRY& RecordingEntry)
+{
+  PVR_RECORDING_ENTRY entry = RecordingEntry;
+  KODI_LOG(ADDON::LOG_DEBUG, "Deleting recording %s", entry.Recording.strTitle);
+  g.RECORDER->setLock();
+  r_HDRecJob->delRecEntry(entry.iRecordingId);
+  g.RECORDER->setUnlock();
+}
+
+void HDRecorder::CreateRecordingItem (const PVR_REC_JOB_ENTRY& RecJobEntry, PVR_RECORDING_ENTRY& RecordingEntry)
+{
+  PVR_CHANNEL channel;
+  channel.iUniqueId = RecJobEntry.Timer.iClientChannelUid;
+  g.RECORDER->setLock();
+  RecordingEntry.iRecordingId = GetRecordingsAmount();
+
+  strncpy(RecordingEntry.Recording.strRecordingId, std::to_string(GetRecordingsAmount()).c_str(), sizeof(RecordingEntry.Recording.strRecordingId) - 1);
+  RecordingEntry.Recording.strRecordingId[sizeof(RecordingEntry.Recording.strRecordingId) - 1] = '\0';
+  strncpy(RecordingEntry.Recording.strTitle, RecJobEntry.Timer.strTitle, sizeof(RecordingEntry.Recording.strTitle) - 1);
+  RecordingEntry.Recording.strTitle[sizeof(RecordingEntry.Recording.strTitle) - 1] = '\0';
+  strncpy(RecordingEntry.Recording.strChannelName, RecJobEntry.strChannelName.c_str(), sizeof(RecordingEntry.Recording.strChannelName) - 1);
+  RecordingEntry.Recording.strChannelName[sizeof(RecordingEntry.Recording.strChannelName) - 1] = '\0';
+
+  RecordingEntry.Recording.iPlayCount = 0;
+  RecordingEntry.Recording.recordingTime = RecJobEntry.Timer.startTime;
+
+//  std::string strFileLocation = g.Settings.strRecPath + RecJobEntry.Timer.strTitle + ".mpeg2";
+  RecordingEntry.strFileLocation = g.Settings.strRecPath + RecJobEntry.Timer.strTitle + ".mpeg2";
+// ToDo:
+//  strncpy(RecordingEntry.Recording.strDirectory, jsonRecording["PVR_RECORDING"]["strDirectory"].asString().c_str(), sizeof(RecordingEntry.Recording.strDirectory) - 1);
+//  RecordingEntry.Recording.iDuration = jsonRecording["PVR_RECORDING"]["iDuration"].asUInt();
+//  RecordingEntry.Recording.iPriority = jsonRecording["PVR_RECORDING"]["iPriority"].asUInt();
+//  RecordingEntry.Recording.iLifetime = jsonRecording["PVR_RECORDING"]["iLifetime"].asUInt();
+
+  EPG_TAG tag;
+  PVR_ERROR myData = g.Tuners->GetEPGTagForChannel(tag, channel, RecJobEntry.Timer.startTime, RecJobEntry.Timer.endTime);
+  if (myData == PVR_ERROR_NO_ERROR)
+  {
+    strncpy(RecordingEntry.Recording.strEpisodeName, tag.strEpisodeName, sizeof(RecordingEntry.Recording.strEpisodeName) - 1);
+    RecordingEntry.Recording.strEpisodeName[sizeof(RecordingEntry.Recording.strEpisodeName) - 1] = '\0';
+    strncpy(RecordingEntry.Recording.strPlotOutline, tag.strPlotOutline, sizeof(RecordingEntry.Recording.strPlotOutline) - 1);
+    RecordingEntry.Recording.strPlotOutline[sizeof(RecordingEntry.Recording.strPlotOutline) - 1] = '\0';
+    strncpy(RecordingEntry.Recording.strPlot, tag.strPlot, sizeof(RecordingEntry.Recording.strPlot) - 1);
+    RecordingEntry.Recording.strPlot[sizeof(RecordingEntry.Recording.strPlot) - 1] = '\0';
+    strncpy(RecordingEntry.Recording.strIconPath, tag.strIconPath, sizeof(RecordingEntry.Recording.strIconPath) - 1);
+    RecordingEntry.Recording.strIconPath[sizeof(RecordingEntry.Recording.strIconPath) - 1] = '\0';
+    RecordingEntry.Recording.iSeriesNumber = tag.iSeriesNumber;
+    RecordingEntry.Recording.iEpisodeNumber = tag.iEpisodeNumber;
+    RecordingEntry.Recording.iGenreType = tag.iGenreType;
+  }
+  g.RECORDER->setUnlock();
+}
+
+std::string HDRecorder::GetRecordingFile (const PVR_RECORDING* RecordingEntry)
+{
+  PVR_RECORDING_ENTRY entry;
+  g.RECORDER->setLock();
+  if (r_HDRecJob->getRecEntry(RecordingEntry->strRecordingId, entry))
+  {
+//    RecordingFile = entry.strFileLocation;
+    g.RECORDER->setUnlock();
+    return entry.strFileLocation;
+  }
+
+  g.RECORDER->setUnlock();
+  return "";
+}

--- a/src/HDRecorder.h
+++ b/src/HDRecorder.h
@@ -1,0 +1,69 @@
+#pragma once
+/*
+ *  Copyright (C) 2017 Brent Murphy <bmurphy@bcmcs.net>
+ *  https://github.com/fuzzard/pvr.hdhomerun
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include <string>
+
+#include <p8-platform/threads/mutex.h>
+#include "xbmc_pvr_types.h"
+
+#include "client.h"
+#include "HDRecorderUtils.h"
+
+class HDRecorderJob;
+class HDRecorderScheduler;
+
+class HDRecorder
+{
+  public:
+    HDRecorder();
+    ~HDRecorder();
+    PVR_ERROR AddTimer (const PVR_TIMER &timer);
+    PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete);
+    PVR_ERROR GetTimers(ADDON_HANDLE handle);
+    int GetTimersAmount(void);
+    PVR_ERROR GetTimerTypes(PVR_TIMER_TYPE types[], int* size);
+    PVR_ERROR UpdateTimer(const PVR_TIMER &timer);
+    PVR_ERROR GetRecordings(ADDON_HANDLE handle);
+    int GetRecordingsAmount();
+    PVR_ERROR DeleteRecording(const PVR_RECORDING& recording);
+    PVR_ERROR RenameRecording(const PVR_RECORDING& recording);
+    PVR_ERROR SetRecordingPlayCount(const PVR_RECORDING& recording, int count);
+    void setLock (void);
+    void setUnlock (void);
+    bool GetJobChannel(PVR_REC_JOB_ENTRY rec);
+    bool GetTriggerTimerUpdate(void);
+    void SetTriggerTimerUpdate(bool bTimerUpdate);
+    bool GetTriggerRecordingUpdate(void);
+    void SetTriggerRecordingUpdate(bool bRecordingUpdate);
+    bool StartRecording (const PVR_REC_JOB_ENTRY &RecJobEntry);
+    void StopRecording (const PVR_REC_JOB_ENTRY &RecJobEntry);
+    void CreateRecordingItem (const PVR_REC_JOB_ENTRY& RecJobEntry, PVR_RECORDING_ENTRY& RecordingEntry);
+    std::string GetRecordingFile (const PVR_RECORDING* RecordingEntry);
+  private:
+    void DeleteRecordingItem (const PVR_RECORDING_ENTRY &RecordingEntry);
+    HDRecorderJob* r_HDRecJob;
+    HDRecorderScheduler* r_HDRecScheduler;
+    bool bTriggerTimerUpdate;
+    bool bTriggerRecordingUpdate;
+    P8PLATFORM::CMutex rec_mutex;
+};
+

--- a/src/HDRecorderJob.cpp
+++ b/src/HDRecorderJob.cpp
@@ -1,0 +1,490 @@
+/*
+ *  Copyright (C) 2017 Brent Murphy <bmurphy@bcmcs.net>
+ *  https://github.com/fuzzard/pvr.hdhomerun
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "HDRecorderJob.h"
+
+#include <ctime>
+#include <map>
+#include <memory>
+#include <string>
+
+#include <json/json.h>
+#include <json/writer.h>
+
+#include "HDRecorderUtils.h"
+#include "Utils.h"
+
+static const std::string strJobCacheFile = "special://home/userdata/addon_data/pvr.hdhomerun/pvr.hdhomerun_timers.cache";
+static const std::string strRecordingsCacheFile = "special://home/userdata/addon_data/pvr.hdhomerun/pvr.hdhomerun_recordings.cache";
+
+HDRecorderJob::HDRecorderJob ()
+{
+  loadData();
+}
+
+HDRecorderJob::~HDRecorderJob()
+{
+  storeEntryData(JobCache);
+  storeEntryData(RecordingCache);
+  m_RecordJobMap.clear();
+  m_RecordingsMap.clear();
+}
+
+bool HDRecorderJob::loadData()
+{
+  m_RecordJobMap.clear();
+  m_RecordingsMap.clear();
+  CACHE_STATUS retStatus;
+  KODI_LOG(ADDON::LOG_DEBUG, "Loading Timer Cache");
+  retStatus = readCache(JobCache);
+  if (retStatus == CACHE_NOT_EXIST)
+  {
+    KODI_LOG(ADDON::LOG_DEBUG, "Timer Cache Does not exist: %s", strJobCacheFile.c_str());
+    if (!createCache(JobCache))
+    {
+      return false;
+    }
+  }
+  KODI_LOG(ADDON::LOG_DEBUG, "Loading Recorder Cache");
+  retStatus = readCache(RecordingCache);
+  if (retStatus == CACHE_NOT_EXIST)
+  {
+    KODI_LOG(ADDON::LOG_DEBUG, "Recorder Cache Does not exist: %s", strRecordingsCacheFile.c_str());
+    if (!createCache(RecordingCache))
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool HDRecorderJob::createCache(CACHE_TYPE CacheType)
+{
+  std::string strFile;
+
+  switch(CacheType)
+  {
+    case JobCache:
+    {
+      strFile = strJobCacheFile;
+      break;
+    }
+    case RecordingCache:
+    {
+      strFile = strRecordingsCacheFile;
+      break;
+    }
+  }
+
+  void* fileHandle = g.XBMC->OpenFileForWrite(strFile.c_str(), true);
+  if (fileHandle == nullptr)
+  {
+    KODI_LOG(ADDON::LOG_DEBUG, "Unable to create Empty cache file: %s, Cache Type: %d", strFile.c_str(), CacheType);
+    return false;
+  }
+
+  Json::StreamWriterBuilder wbuilder;
+  Json::Value root = Json::arrayValue;
+  std::string emptyCache = Json::writeString(wbuilder, root);
+
+  int writtenbytes = g.XBMC->WriteFile(fileHandle, emptyCache.c_str(), emptyCache.length());
+  g.XBMC->FlushFile(fileHandle);
+  g.XBMC->CloseFile(fileHandle);
+  if (writtenbytes <= 0)
+  {
+    KODI_LOG(ADDON::LOG_ERROR, "Empty Cache File Creation failed: %s ", strFile.c_str());
+    return false;
+  }
+  KODI_LOG(ADDON::LOG_DEBUG, "Empty Cache File Created: %s", strFile.c_str());
+  return true;
+}
+
+HDRecorderJob::CACHE_STATUS HDRecorderJob::readCache(CACHE_TYPE CacheType)
+{
+  std::string strFile, strJson, jsonReaderError;
+  Json::CharReaderBuilder jsonReaderBuilder;
+  std::unique_ptr<Json::CharReader> const jsonReader(jsonReaderBuilder.newCharReader());
+  Json::Value jsonCache;
+
+  switch(CacheType)
+  {
+    case JobCache:
+    {
+      strFile = strJobCacheFile;
+      break;
+    }
+    case RecordingCache:
+    {
+      strFile = strRecordingsCacheFile;
+      break;
+    }
+  }
+
+  if (g.XBMC->FileExists(strFile.c_str(), false))
+  {
+    if (GetFileContents(strFile, strJson))
+    {
+      if (jsonReader->parse(strJson.c_str(), strJson.c_str() + strJson.size(), &jsonCache, &jsonReaderError) &&
+          jsonCache.type() == Json::arrayValue)
+      {
+        switch(CacheType)
+        {
+          case JobCache:
+          {
+            for (auto& jsonTimer : jsonCache)
+            {
+              PVR_REC_JOB_ENTRY jobEntry;
+              ParseJsonJob(jsonTimer, jobEntry);
+              if (jobEntry.Timer.state == PVR_TIMER_STATE_NEW || jobEntry.Timer.state == PVR_TIMER_STATE_SCHEDULED)
+              {
+                if (jobEntry.Timer.startTime > time(NULL))
+                {
+                  jobEntry.Status = PVR_STREAM_NO_STREAM;
+                  m_RecordJobMap[jobEntry.Timer.iClientIndex] = jobEntry;
+                }
+              }
+            }
+            KODI_LOG(ADDON::LOG_DEBUG, "Timer Cache loaded %d entries", m_RecordJobMap.size());
+            return CACHE_LOADED;
+          }
+          case RecordingCache:
+          {
+            for (auto& jsonRecording : jsonCache)
+            {
+              PVR_RECORDING_ENTRY RecordingEntry;
+              ParseJsonRecording(jsonRecording, RecordingEntry);
+              m_RecordingsMap[RecordingEntry.iRecordingId] = RecordingEntry;
+            }
+            KODI_LOG(ADDON::LOG_DEBUG, "Recording Cache loaded %d entries", m_RecordingsMap.size());
+            return CACHE_LOADED;
+          }
+        }
+      }
+      else
+      {
+        KODI_LOG(ADDON::LOG_ERROR, "Unable to parse Cache: %s", strFile.c_str());
+        return CACHE_PARSE_FAILED;
+      }
+    }
+    KODI_LOG(ADDON::LOG_ERROR, "Failed to read Cache: %s", strFile.c_str());
+    return CACHE_READ_FAILED;
+  } 
+  return CACHE_NOT_EXIST;
+}
+
+bool HDRecorderJob::storeEntryData (CACHE_TYPE CacheType)
+{
+  std::string strFile;
+
+  switch(CacheType)
+  {
+    case JobCache:
+    {
+      strFile = strJobCacheFile;
+      break;
+    }
+    case RecordingCache:
+    {
+      strFile = strRecordingsCacheFile;
+      break;
+    }
+  }
+  KODI_LOG(ADDON::LOG_DEBUG, "Storing Cache Data: %s", strFile.c_str());
+
+  void* fileHandle = g.XBMC->OpenFileForWrite(strFile.c_str(), true);
+
+  if (fileHandle == nullptr)
+  {
+    KODI_LOG(ADDON::LOG_ERROR, "Unable to open cache file for write: %s ", strFile.c_str());
+    return false;
+  }
+  Json::StreamWriterBuilder wbuilder;
+  std::string outputJsonCache;
+  Json::Value::ArrayIndex nIndex = 0;
+  switch(CacheType)
+  {
+    case JobCache:
+    {
+      Json::Value Timers = Json::arrayValue;
+      for (auto& it : m_RecordJobMap)
+      {
+        Json::Value jsonRecJob;
+        CreateJsonJob(jsonRecJob, it.second);
+        Timers[nIndex] = jsonRecJob;
+        KODI_LOG(ADDON::LOG_DEBUG, "Timer JSON Entry: %s ", Timers[nIndex]["Title"].asString().c_str());
+        nIndex++;
+      }
+      outputJsonCache.append(Json::writeString(wbuilder, Timers));
+      break;
+    }
+    case RecordingCache:
+    {
+      Json::Value Recordings = Json::arrayValue;
+      for (auto& it : m_RecordingsMap)
+      {
+        Json::Value jsonRecording;
+        CreateJsonRecording(jsonRecording, it.second);
+        Recordings[nIndex] = jsonRecording;
+        nIndex++;
+      }
+      outputJsonCache.append(Json::writeString(wbuilder, Recordings));
+      break;
+    }
+  }
+  KODI_LOG(ADDON::LOG_DEBUG, "Data being written: %s", outputJsonCache.c_str());
+  int writtenbytes = g.XBMC->WriteFile(fileHandle, outputJsonCache.c_str(), outputJsonCache.length());
+  g.XBMC->FlushFile(fileHandle);
+  g.XBMC->CloseFile(fileHandle);
+  if (writtenbytes <= 0)
+  {
+    KODI_LOG(ADDON::LOG_ERROR, "Write to Cache File failed: %s ", strFile.c_str());
+    return false;
+  }
+  return true;
+}
+
+std::map<int,PVR_REC_JOB_ENTRY> HDRecorderJob::getEntryData(void)
+{
+  return m_RecordJobMap;
+}
+
+std::map<int,PVR_RECORDING_ENTRY> HDRecorderJob::getEntryData(HDRecorderJob::CACHE_TYPE CacheType)
+{
+  return m_RecordingsMap;
+}
+
+bool HDRecorderJob::addJobEntry(const PVR_REC_JOB_ENTRY &RecJobEntry)
+{
+  if (m_RecordJobMap.find(RecJobEntry.Timer.iClientIndex) == m_RecordJobMap.end())
+  {
+    KODI_LOG(ADDON::LOG_DEBUG, "Add Timer entry %s", RecJobEntry.Timer.strTitle);
+    m_RecordJobMap[RecJobEntry.Timer.iClientIndex] = RecJobEntry;
+    storeEntryData(JobCache);
+    return true;
+  }
+
+  return false;
+}
+
+bool HDRecorderJob::getJobEntry(const int ientryIndex, PVR_REC_JOB_ENTRY &entry)
+{
+  if (m_RecordJobMap.find(ientryIndex) == m_RecordJobMap.end()) 
+    return false;
+
+  entry = m_RecordJobMap[ientryIndex];
+  return true;
+}
+
+bool HDRecorderJob::getJobEntry(const std::string strChannelName, PVR_REC_JOB_ENTRY &entry)
+{
+  for (const auto& it : m_RecordJobMap)
+    if (it.second.strChannelName==strChannelName)
+    {
+      entry = it.second;
+      return true;
+    }
+
+  return false;
+}
+
+bool HDRecorderJob::updateJobEntry(const PVR_REC_JOB_ENTRY &RecJobEntry)
+{
+  PVR_REC_JOB_ENTRY entry = RecJobEntry;
+  if (getJobEntry(RecJobEntry.Timer.iClientIndex ,entry))
+  {
+    entry = RecJobEntry;
+
+    m_RecordJobMap[RecJobEntry.Timer.iClientIndex] = entry;
+    storeEntryData(JobCache);
+    KODI_LOG(ADDON::LOG_DEBUG, "Updated Timer entry %s", RecJobEntry.Timer.strTitle);
+    return true; 
+  }
+  return false;
+}
+
+bool HDRecorderJob::delJobEntry(const int ientryIndex)
+{
+  PVR_REC_JOB_ENTRY entry;
+  if (HDRecorderJob::getJobEntry(ientryIndex ,entry))
+  {
+    KODI_LOG(ADDON::LOG_DEBUG, "Deleted job entry %s", entry.Timer.strTitle);
+    m_RecordJobMap.erase(ientryIndex);
+    storeEntryData(JobCache);
+    return true;
+  }
+  return false;
+}
+
+bool HDRecorderJob::addRecEntry(const PVR_RECORDING_ENTRY &entry)
+{
+  if (m_RecordingsMap.find(entry.iRecordingId) == m_RecordingsMap.end())
+  {
+    KODI_LOG(ADDON::LOG_DEBUG, "Add Recording entry %s", entry.Recording.strTitle);
+    m_RecordingsMap[entry.iRecordingId] = entry;
+    storeEntryData(RecordingCache);
+    return true;
+  }
+
+  return false;
+}
+
+bool HDRecorderJob::getRecEntry(const int iRecordingId, PVR_RECORDING_ENTRY &entry)
+{
+  if (m_RecordingsMap.find(iRecordingId) == m_RecordingsMap.end()) 
+    return false;
+
+  entry = m_RecordingsMap[iRecordingId];
+  return true;
+}
+
+bool HDRecorderJob::getRecEntry(const std::string strRecId, PVR_RECORDING_ENTRY &entry)
+{
+  for (const auto& it : m_RecordingsMap)
+    if (it.second.Recording.strRecordingId == strRecId)
+    {
+      entry = it.second;
+      return true;
+    }
+
+  return false;
+}
+
+bool HDRecorderJob::delRecEntry(const int iRecordingId)
+{
+  PVR_RECORDING_ENTRY entry;
+  if (HDRecorderJob::getRecEntry(iRecordingId ,entry))
+  {
+    KODI_LOG(ADDON::LOG_DEBUG, "Deleted Recording entry %s", entry.Recording.strTitle);
+    m_RecordingsMap.erase(iRecordingId);
+    storeEntryData(RecordingCache);
+    return true;
+  }
+  return false;
+}
+
+void HDRecorderJob::updateRecEntry(const PVR_RECORDING_ENTRY &RecJobEntry)
+{
+  PVR_RECORDING_ENTRY entry = RecJobEntry;
+  m_RecordingsMap[RecJobEntry.iRecordingId] = entry;
+  storeEntryData(RecordingCache);
+  KODI_LOG(ADDON::LOG_DEBUG, "Updated Recording entry %s", RecJobEntry.Recording.strTitle);
+}
+
+void HDRecorderJob::ParseJsonRecording(Json::Value& jsonRecording, PVR_RECORDING_ENTRY& RecordingEntry)
+{
+  RecordingEntry.Status = static_cast<PVR_RECORDING_STATUS>(jsonRecording["Status"].asUInt());
+  RecordingEntry.iRecordingId = jsonRecording["iRecordingId"].asUInt();
+  RecordingEntry.strFileLocation = jsonRecording["strFileLocation"].asString();
+  strncpy(RecordingEntry.Recording.strTitle, jsonRecording["PVR_RECORDING"]["strTitle"].asString().c_str(), sizeof(RecordingEntry.Recording.strTitle) - 1);
+  RecordingEntry.Recording.strTitle[sizeof(RecordingEntry.Recording.strTitle) - 1] = '\0';
+  strncpy(RecordingEntry.Recording.strRecordingId, jsonRecording["PVR_RECORDING"]["strRecordingId"].asString().c_str(), sizeof(RecordingEntry.Recording.strRecordingId) - 1);
+  RecordingEntry.Recording.strRecordingId[sizeof(RecordingEntry.Recording.strRecordingId) - 1] = '\0';
+  strncpy(RecordingEntry.Recording.strEpisodeName, jsonRecording["PVR_RECORDING"]["strEpisodeName"].asString().c_str(), sizeof(RecordingEntry.Recording.strEpisodeName) - 1);
+  RecordingEntry.Recording.strEpisodeName[sizeof(RecordingEntry.Recording.strEpisodeName) - 1] = '\0';
+  RecordingEntry.Recording.iSeriesNumber = jsonRecording["PVR_RECORDING"]["iSeriesNumber"].asUInt();
+  RecordingEntry.Recording.iEpisodeNumber = jsonRecording["PVR_RECORDING"]["iEpisodeNumber"].asUInt();
+  RecordingEntry.Recording.iYear = jsonRecording["PVR_RECORDING"]["iYear"].asUInt();
+  strncpy(RecordingEntry.Recording.strDirectory, jsonRecording["PVR_RECORDING"]["strDirectory"].asString().c_str(), sizeof(RecordingEntry.Recording.strDirectory) - 1);
+  RecordingEntry.Recording.strDirectory[sizeof(RecordingEntry.Recording.strDirectory) - 1] = '\0';
+  strncpy(RecordingEntry.Recording.strPlotOutline, jsonRecording["PVR_RECORDING"]["strPlotOutline"].asString().c_str(), sizeof(RecordingEntry.Recording.strPlotOutline) - 1);
+  RecordingEntry.Recording.strPlotOutline[sizeof(RecordingEntry.Recording.strPlotOutline) - 1] = '\0';
+  strncpy(RecordingEntry.Recording.strPlot, jsonRecording["PVR_RECORDING"]["strPlot"].asString().c_str(), sizeof(RecordingEntry.Recording.strPlot) - 1);
+  RecordingEntry.Recording.strPlot[sizeof(RecordingEntry.Recording.strPlot) - 1] = '\0';
+  strncpy(RecordingEntry.Recording.strChannelName, jsonRecording["PVR_RECORDING"]["strChannelName"].asString().c_str(), sizeof(RecordingEntry.Recording.strChannelName) - 1);
+  RecordingEntry.Recording.strChannelName[sizeof(RecordingEntry.Recording.strChannelName) - 1] = '\0';
+  RecordingEntry.Recording.recordingTime = static_cast<time_t>(std::stol(jsonRecording["PVR_RECORDING"]["recordingTime"].asString()));
+  RecordingEntry.Recording.iDuration = jsonRecording["PVR_RECORDING"]["iDuration"].asUInt();
+  RecordingEntry.Recording.iPriority = jsonRecording["PVR_RECORDING"]["iPriority"].asUInt();
+  RecordingEntry.Recording.iLifetime = jsonRecording["PVR_RECORDING"]["iLifetime"].asUInt();
+  RecordingEntry.Recording.iGenreType = jsonRecording["PVR_RECORDING"]["iGenreType"].asUInt();
+  RecordingEntry.Recording.iPlayCount = jsonRecording["PVR_RECORDING"]["iPlayCount"].asUInt();
+}
+
+void HDRecorderJob::CreateJsonRecording(Json::Value& jsonRecording, PVR_RECORDING_ENTRY& RecordingEntry)
+{
+  jsonRecording["Status"] = RecordingEntry.Status;
+  jsonRecording["iRecordingId"] = RecordingEntry.iRecordingId;
+  jsonRecording["strFileLocation"] = RecordingEntry.strFileLocation;
+  jsonRecording["PVR_RECORDING"]["strTitle"] = RecordingEntry.Recording.strTitle;
+  jsonRecording["PVR_RECORDING"]["strRecordingId"] = RecordingEntry.Recording.strRecordingId;
+  jsonRecording["PVR_RECORDING"]["strEpisodeName"] = RecordingEntry.Recording.strEpisodeName;
+  jsonRecording["PVR_RECORDING"]["iSeriesNumber"] = RecordingEntry.Recording.iSeriesNumber;
+  jsonRecording["PVR_RECORDING"]["iEpisodeNumber"] = RecordingEntry.Recording.iEpisodeNumber;
+  jsonRecording["PVR_RECORDING"]["iYear"] = RecordingEntry.Recording.iYear;
+  jsonRecording["PVR_RECORDING"]["strDirectory"] = RecordingEntry.Recording.strDirectory;
+  jsonRecording["PVR_RECORDING"]["strPlotOutline"] = RecordingEntry.Recording.strPlotOutline;
+  jsonRecording["PVR_RECORDING"]["strPlot"] = RecordingEntry.Recording.strPlot;
+  jsonRecording["PVR_RECORDING"]["strChannelName"] = RecordingEntry.Recording.strChannelName;
+  jsonRecording["PVR_RECORDING"]["recordingTime"] = std::to_string(RecordingEntry.Recording.recordingTime);
+  jsonRecording["PVR_RECORDING"]["iDuration"] = RecordingEntry.Recording.iDuration;
+  jsonRecording["PVR_RECORDING"]["iPriority"] = RecordingEntry.Recording.iPriority;
+  jsonRecording["PVR_RECORDING"]["iLifetime"] = RecordingEntry.Recording.iLifetime;
+  jsonRecording["PVR_RECORDING"]["iGenreType"] = RecordingEntry.Recording.iGenreType;
+  jsonRecording["PVR_RECORDING"]["iPlayCount"] = RecordingEntry.Recording.iPlayCount;
+}
+
+bool HDRecorderJob::ParseJsonJob(Json::Value& jsonRecJob, PVR_REC_JOB_ENTRY& RecJobEntry)
+{
+  RecJobEntry.Timer.iClientIndex = jsonRecJob["PVR_TIMER"]["iClientIndex"].asUInt();
+  if (RecJobEntry.Timer.iClientIndex == PVR_TIMER_NO_CLIENT_INDEX)
+    return false;
+  RecJobEntry.Timer.iClientChannelUid = jsonRecJob["PVR_TIMER"]["iClientChannelUid"].asUInt();
+  RecJobEntry.strChannelName = jsonRecJob["GuideName"].asString();
+  RecJobEntry.strGuideNumber = jsonRecJob["GuideNumber"].asString();
+  strncpy(RecJobEntry.Timer.strTitle, jsonRecJob["Title"].asString().c_str(), sizeof(RecJobEntry.Timer.strTitle) - 1);
+  RecJobEntry.Timer.strTitle[sizeof(RecJobEntry.Timer.strTitle) - 1] = '\0';
+  RecJobEntry.Timer.startTime = static_cast<time_t>(std::stol(jsonRecJob["PVR_TIMER"]["startTime"].asString()));
+  RecJobEntry.Timer.endTime  = static_cast<time_t>(std::stol(jsonRecJob["PVR_TIMER"]["endTime"].asString()));
+  if (jsonRecJob["PVR_TIMER"]["state"].asInt() < 0 || jsonRecJob["PVR_TIMER"]["state"].asUInt() > 10)
+    return false;
+  RecJobEntry.Timer.state = static_cast<PVR_TIMER_STATE>(jsonRecJob["PVR_TIMER"]["state"].asUInt());
+  RecJobEntry.Timer.iPriority = jsonRecJob["PVR_TIMER"]["iPriority"].asUInt();
+  RecJobEntry.Timer.iLifetime = jsonRecJob["PVR_TIMER"]["iLifetime"].asUInt();
+  RecJobEntry.Timer.firstDay = static_cast<time_t>(std::stol(jsonRecJob["PVR_TIMER"]["firstDay"].asString()));
+  RecJobEntry.Timer.iWeekdays = jsonRecJob["PVR_TIMER"]["iWeekdays"].asUInt();
+  RecJobEntry.Timer.iEpgUid = jsonRecJob["PVR_TIMER"]["iEpgUid"].asUInt();
+  RecJobEntry.Timer.iMarginStart = jsonRecJob["PVR_TIMER"]["iMarginStart"].asUInt();
+  RecJobEntry.Timer.iMarginEnd = jsonRecJob["PVR_TIMER"]["iMarginEnd"].asUInt();
+  RecJobEntry.Timer.iGenreType = jsonRecJob["PVR_TIMER"]["iGenreType"].asUInt();
+  RecJobEntry.Timer.iGenreSubType = jsonRecJob["PVR_TIMER"]["iGenreSubType"].asUInt();
+  return true;
+}
+
+void HDRecorderJob::CreateJsonJob(Json::Value& jsonRecJob, PVR_REC_JOB_ENTRY& RecJobEntry)
+{
+  jsonRecJob["GuideName"] = RecJobEntry.strChannelName;
+  jsonRecJob["GuideNumber"] = RecJobEntry.strGuideNumber;
+  jsonRecJob["Title"] = RecJobEntry.Timer.strTitle;
+  jsonRecJob["PVR_TIMER"]["iClientIndex"] = RecJobEntry.Timer.iClientIndex;
+  jsonRecJob["PVR_TIMER"]["iClientChannelUid"] = RecJobEntry.Timer.iClientChannelUid;
+  jsonRecJob["PVR_TIMER"]["startTime"] = std::to_string(RecJobEntry.Timer.startTime);
+  jsonRecJob["PVR_TIMER"]["endTime"] = std::to_string(RecJobEntry.Timer.endTime);
+  jsonRecJob["PVR_TIMER"]["state"] = RecJobEntry.Timer.state;
+  jsonRecJob["PVR_TIMER"]["iPriority"] = RecJobEntry.Timer.iPriority;
+  jsonRecJob["PVR_TIMER"]["iLifetime"] = RecJobEntry.Timer.iLifetime;
+  jsonRecJob["PVR_TIMER"]["firstDay"] = std::to_string(RecJobEntry.Timer.firstDay);
+  jsonRecJob["PVR_TIMER"]["iWeekdays"] = RecJobEntry.Timer.iWeekdays;
+  jsonRecJob["PVR_TIMER"]["iEpgUid"] = RecJobEntry.Timer.iEpgUid;
+  jsonRecJob["PVR_TIMER"]["iMarginStart"] = RecJobEntry.Timer.iMarginStart;
+  jsonRecJob["PVR_TIMER"]["iMarginEnd"] = RecJobEntry.Timer.iMarginEnd;
+  jsonRecJob["PVR_TIMER"]["iGenreType"] = RecJobEntry.Timer.iGenreType;
+  jsonRecJob["PVR_TIMER"]["iGenreSubType"] = RecJobEntry.Timer.iGenreSubType;
+}

--- a/src/HDRecorderJob.h
+++ b/src/HDRecorderJob.h
@@ -1,0 +1,77 @@
+#pragma once
+/*
+ *  Copyright (C) 2017 Brent Murphy <bmurphy@bcmcs.net>
+ *  https://github.com/fuzzard/pvr.hdhomerun
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include <map>
+#include <string>
+
+#include <json/json.h>
+
+#include "HDRecorderUtils.h"
+
+class HDRecorderJob
+{
+public:
+  typedef enum
+  {
+    JobCache = 1,
+    RecordingCache = 2,
+  } CACHE_TYPE;
+
+private:
+  typedef enum
+  {
+    CACHE_NOT_EXIST = 0,
+    CACHE_LOADED = 1,
+    CACHE_PARSE_FAILED = 2,
+    CACHE_READ_FAILED = 3,
+  } CACHE_STATUS;
+
+public:
+    HDRecorderJob(void);
+    ~HDRecorderJob(void);
+    std::map<int,PVR_REC_JOB_ENTRY> getEntryData(void);
+    std::map<int,PVR_RECORDING_ENTRY> getEntryData(CACHE_TYPE CacheType);
+    // timers
+    bool addJobEntry(const PVR_REC_JOB_ENTRY &RecJobEntry);
+    bool getJobEntry(const int ientryIndex, PVR_REC_JOB_ENTRY &entry);
+    bool getJobEntry(const std::string strChannelName, PVR_REC_JOB_ENTRY &entry);
+    bool updateJobEntry(const PVR_REC_JOB_ENTRY &RecJobEntry);
+    bool delJobEntry(const int ientryIndex);
+    // recordings
+    bool addRecEntry(const PVR_RECORDING_ENTRY &entry);
+    bool getRecEntry(const int iRecordingId, PVR_RECORDING_ENTRY &entry);
+    bool getRecEntry(const std::string strRecId, PVR_RECORDING_ENTRY &entry);
+    void updateRecEntry(const PVR_RECORDING_ENTRY &RecJobEntry);
+    bool delRecEntry(const int ientryIndex);
+
+private:
+    std::map <int,PVR_REC_JOB_ENTRY> m_RecordJobMap;
+    std::map <int,PVR_RECORDING_ENTRY> m_RecordingsMap;
+    bool createCache(CACHE_TYPE CacheType);
+    CACHE_STATUS readCache(CACHE_TYPE CacheType);
+    bool loadData(void);
+    bool storeEntryData (CACHE_TYPE CacheType);
+    void CreateJsonJob(Json::Value& jsonRecJob, PVR_REC_JOB_ENTRY& RecJobEntry);
+    bool ParseJsonJob(Json::Value& jsonRecJob, PVR_REC_JOB_ENTRY& RecJobEntry);
+    void CreateJsonRecording(Json::Value& jsonRecording, PVR_RECORDING_ENTRY& RecordingEntry);
+    void ParseJsonRecording(Json::Value& jsonRecording, PVR_RECORDING_ENTRY& RecordingEntry);
+};

--- a/src/HDRecorderScheduler.cpp
+++ b/src/HDRecorderScheduler.cpp
@@ -1,0 +1,131 @@
+/*
+ *  Copyright (C) 2017 Brent Murphy <bmurphy@bcmcs.net>
+ *  https://github.com/fuzzard/pvr.hdhomerun
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "HDRecorderScheduler.h"
+
+#include <map>
+#include <ctime>
+
+#include <p8-platform/threads/threads.h>
+
+#include "client.h"
+#include "HDRecorder.h"
+#include "HDRecorderJob.h"
+#include "Utils.h"
+
+HDRecorderScheduler::HDRecorderScheduler(HDRecorderJob* r_HDRecJob)
+{
+  t_HDRecJob = r_HDRecJob;
+  b_interval = 10;
+  tLastCheck = time(nullptr) - b_interval;
+  isRunning = false;
+  b_stop = false;
+  P8PLATFORM::CThread::CreateThread();
+}
+
+HDRecorderScheduler::~HDRecorderScheduler(void)
+{
+  b_stop = true;
+  KODI_LOG(ADDON::LOG_NOTICE, "Closing scheduler thread");
+  this->P8PLATFORM::CThread::StopThread(0);
+}
+
+void HDRecorderScheduler::StopThread(bool bWait)
+{
+  b_stop = true;
+}
+
+void* HDRecorderScheduler::Process(void)
+{
+  KODI_LOG(ADDON::LOG_NOTICE,"Starting scheduler thread");
+  isRunning = true;
+  while (true) {
+    if (b_stop == true)
+    {
+      isRunning = false;
+      return nullptr;
+    }
+    time_t now = time(nullptr);
+    if (now >= (tLastCheck + b_interval)) {
+      g.RECORDER->setLock();
+      std::map<int,PVR_REC_JOB_ENTRY> RecJobs = t_HDRecJob->getEntryData();
+      for (const auto& rec : RecJobs)
+      {
+        if (rec.second.Status == PVR_STREAM_STOPPED)
+        {
+          KODI_LOG(ADDON::LOG_NOTICE, "Try to delete Timer %s", rec.second.Timer.strTitle);
+          t_HDRecJob->delJobEntry(rec.first);
+          g.RECORDER->SetTriggerTimerUpdate(true);
+        }
+        else if (rec.second.Timer.endTime < time(nullptr))
+        {
+          KODI_LOG(ADDON::LOG_NOTICE, "Try to delete Timer %s", rec.second.Timer.strTitle);
+          t_HDRecJob->delJobEntry(rec.first);
+          g.RECORDER->SetTriggerTimerUpdate(true);
+        }
+        else if ((rec.second.Timer.startTime - 10) <= time(nullptr) && rec.second.Timer.state == PVR_TIMER_STATE_SCHEDULED)
+        {
+          KODI_LOG(ADDON::LOG_NOTICE, "Try to start recording %s", rec.second.Timer.strTitle);
+          g.RECORDER->StartRecording(rec.second);
+          g.RECORDER->SetTriggerTimerUpdate(true);
+        }
+        else if (rec.second.Timer.endTime <= time(nullptr) && (rec.second.Timer.state == PVR_TIMER_STATE_RECORDING))
+        {
+          KODI_LOG(ADDON::LOG_NOTICE, "Try to stop recording %s", rec.second.Timer.strTitle);
+          PVR_RECORDING_ENTRY RecordingEntry;
+          RecordingEntry.Status = PVR_RECORDING_COMPLETED;
+          g.RECORDER->StopRecording(rec.second);
+          g.RECORDER->CreateRecordingItem(rec.second, RecordingEntry);
+          t_HDRecJob->updateRecEntry(RecordingEntry);
+          g.RECORDER->SetTriggerTimerUpdate(true);
+          g.RECORDER->SetTriggerRecordingUpdate(true);
+        }
+      }
+      g.RECORDER->setUnlock();
+
+      if (g.RECORDER->GetTriggerTimerUpdate())
+      {
+        g.RECORDER->SetTriggerTimerUpdate(false);
+        try {
+          g.PVR->TriggerTimerUpdate();
+        }catch( std::exception const & e ) {
+          //Closing Kodi, TriggerTimerUpdate is not available
+          // MSVC throws warning C4101: 'e': unreferenced local variable without
+          (void)e;
+        }
+      }
+      if (g.RECORDER->GetTriggerRecordingUpdate())
+      {
+        g.RECORDER->SetTriggerRecordingUpdate(false);
+        KODI_LOG(ADDON::LOG_DEBUG,"Recording Trigger Updating");
+        try {
+          g.PVR->TriggerRecordingUpdate();
+        }catch( std::exception const & e ) {
+          //Closing Kodi, TriggerTimerUpdate is not available
+          // MSVC throws warning C4101: 'e': unreferenced local variable without
+          (void)e;
+        }
+      }
+      tLastCheck = time(nullptr);
+    }
+  }
+  return nullptr;
+}

--- a/src/HDRecorderScheduler.h
+++ b/src/HDRecorderScheduler.h
@@ -1,0 +1,40 @@
+#pragma once
+/*
+ *  Copyright (C) 2017 Brent Murphy <bmurphy@bcmcs.net>
+ *  https://github.com/fuzzard/pvr.hdhomerun
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include <p8-platform/threads/threads.h>
+
+class HDRecorderJob;
+
+class HDRecorderScheduler : P8PLATFORM::CThread
+{
+  public: 
+    HDRecorderScheduler(HDRecorderJob* r_HDRecJob);
+    virtual ~HDRecorderScheduler(void);
+    virtual void StopThread(bool bWait = true);
+    virtual void *Process(void);
+  private: 
+    bool b_stop;
+    bool isRunning;
+    time_t tLastCheck;
+    int b_interval;
+    HDRecorderJob* t_HDRecJob;
+};

--- a/src/HDRecorderThread.cpp
+++ b/src/HDRecorderThread.cpp
@@ -1,0 +1,156 @@
+/*
+ *  Copyright (C) 2017 Brent Murphy <bmurphy@bcmcs.net>
+ *  https://github.com/fuzzard/pvr.hdhomerun
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "HDRecorderThread.h"
+
+#include <ctime>
+#include <algorithm>
+
+#include <p8-platform/threads/threads.h>
+#include <p8-platform/util/StringUtils.h>
+
+#include "client.h"
+#include "HDHomeRunTuners.h"
+#include "HDRecorder.h"
+#include "HDRecorderJob.h"
+#include "HDRecorderUtils.h"
+#include "Utils.h"
+
+HDRecorderThread::HDRecorderThread(int iClientIndex, HDRecorderJob* r_HDRecJob)
+{
+  t_HDRecJob = r_HDRecJob;
+  isRunning = false;
+  b_stop = false;
+  t_iClientIndex = iClientIndex;
+  P8PLATFORM::CThread::CreateThread();
+}
+
+HDRecorderThread::~HDRecorderThread(void)
+{
+  b_stop = true;
+  this->P8PLATFORM::CThread::StopThread(0);
+  KODI_LOG(ADDON::LOG_DEBUG, "HDRecorderThread Deleted");
+}
+
+void HDRecorderThread::StopThread(bool bWait)
+{
+  b_stop = true;
+}
+
+void* HDRecorderThread::Process(void)
+{
+  PVR_REC_JOB_ENTRY entry;
+  g.RECORDER->setLock();
+  t_HDRecJob->getJobEntry(t_iClientIndex, entry);
+  entry.Status = PVR_STREAM_IS_RECORDING;
+  t_HDRecJob->updateJobEntry(entry);
+  g.RECORDER->setUnlock();
+
+  isRunning = true;
+
+  time_t duration = entry.Timer.endTime-entry.Timer.startTime;
+  t_duration = duration;
+  KODI_LOG(ADDON::LOG_DEBUG, "Duration: %d, ClientIndex: %d", duration, t_iClientIndex);
+  std::string strUrl = g.Tuners->_GetChannelStreamURL(entry.Timer.iClientChannelUid);
+  if (strUrl.empty())
+  {
+    KODI_LOG(ADDON::LOG_NOTICE, "Cannot find stream with valid channel");
+    g.RECORDER->setLock();
+    entry.Status = PVR_STREAM_STOPPED;
+    entry.Timer.state= PVR_TIMER_STATE_ABORTED;
+    t_HDRecJob->updateJobEntry(entry);
+    g.RECORDER->setUnlock();
+    g.RECORDER->SetTriggerTimerUpdate(true);
+    isRunning = false;
+    return nullptr;
+  }
+  strUrl = StringUtils::Format("%s?duration=%s", strUrl.c_str(), std::to_string(t_duration).c_str());
+  KODI_LOG(ADDON::LOG_DEBUG, "Try to open stream: %s",  strUrl.c_str());
+
+  // ToDo: set filename to ep info if exists?
+  //       This definitely needs to be looked t to create unique filenames. Possibly 
+  //       have to use date/time to differentiate rather than other supplied tag info
+  std::string fileExtension = ".mpeg2";
+  std::string videoFile = g.Settings.strRecPath + MakeLegalFileName(entry.Timer.strTitle + fileExtension);
+  KODI_LOG(ADDON::LOG_NOTICE, "File to write: %s ", videoFile.c_str());
+
+  void* outputFileHandle = g.XBMC->OpenFileForWrite(videoFile.c_str(), true);
+  if (outputFileHandle == nullptr)
+  {
+    KODI_LOG(ADDON::LOG_NOTICE, "Unable to open Output File: %s", videoFile.c_str());
+    g.RECORDER->setLock();
+    entry.Status = PVR_STREAM_STOPPED;
+    entry.Timer.state= PVR_TIMER_STATE_ABORTED;
+    t_HDRecJob->updateJobEntry(entry);
+    g.RECORDER->setUnlock();
+    g.RECORDER->SetTriggerTimerUpdate(true);
+    isRunning = false;
+    return nullptr;
+  }
+// Need to detect 503 for no available tuner
+  void* streamFileHandle = g.XBMC->OpenFile(strUrl.c_str(), 0);
+  if (streamFileHandle == nullptr)
+  {
+    KODI_LOG(ADDON::LOG_NOTICE, "Unable to open Source Stream: %s", strUrl.c_str());
+    g.RECORDER->setLock();
+    entry.Status = PVR_STREAM_STOPPED;
+    entry.Timer.state = PVR_TIMER_STATE_ABORTED;
+    t_HDRecJob->updateJobEntry(entry);
+    g.RECORDER->setUnlock();
+    g.RECORDER->SetTriggerTimerUpdate(true);
+    isRunning = false;
+    return nullptr;
+  }
+
+  char buffer[1024];
+
+  for (;;)
+  {
+    ssize_t bytesRead = g.XBMC->ReadFile(streamFileHandle, buffer, sizeof(buffer));
+    if (bytesRead <= 0)
+      break;
+    g.XBMC->WriteFile(outputFileHandle, buffer, bytesRead);
+    std::fill(std::begin(buffer), std::end(buffer), '\0');
+    g.RECORDER->setLock();
+    t_HDRecJob->getJobEntry(t_iClientIndex, entry);
+    g.RECORDER->setUnlock();
+    if (entry.Timer.endTime < time(nullptr) || entry.Status == PVR_STREAM_IS_STOPPING || entry.Status == PVR_STREAM_STOPPED || b_stop)
+      break;
+  }
+  g.XBMC->CloseFile(streamFileHandle);
+  g.XBMC->CloseFile(outputFileHandle);
+  KODI_LOG(ADDON::LOG_NOTICE, "Recording stopped %s ", entry.Timer.strTitle);
+  g.RECORDER->setLock();
+  entry.Status = PVR_STREAM_STOPPED;
+  entry.Timer.state = PVR_TIMER_STATE_COMPLETED;
+  t_HDRecJob->updateJobEntry(entry);
+
+  PVR_RECORDING_ENTRY RecordingEntry;
+  RecordingEntry.Status = PVR_RECORDING_COMPLETED;
+  g.RECORDER->CreateRecordingItem(entry, RecordingEntry);
+  t_HDRecJob->updateRecEntry(RecordingEntry);
+  g.RECORDER->setUnlock();
+
+  g.RECORDER->SetTriggerRecordingUpdate(true);
+  g.RECORDER->SetTriggerTimerUpdate(true);
+  isRunning = false;
+  return nullptr;
+}

--- a/src/HDRecorderThread.h
+++ b/src/HDRecorderThread.h
@@ -1,0 +1,40 @@
+#pragma once
+/*
+ *  Copyright (C) 2017 Brent Murphy <bmurphy@bcmcs.net>
+ *  https://github.com/fuzzard/pvr.hdhomerun
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include <p8-platform/threads/threads.h>
+
+class HDRecorderJob;
+
+class HDRecorderThread : P8PLATFORM::CThread
+{
+  public: 
+    HDRecorderThread(int iClientIndex, HDRecorderJob* r_HDRecJob);
+    virtual ~HDRecorderThread(void);
+    virtual void StopThread(bool bWait = true);
+    virtual void *Process(void);
+  private:
+    bool isRunning;
+    bool b_stop;
+    HDRecorderJob* t_HDRecJob;
+    time_t t_duration;
+    int t_iClientIndex;
+};

--- a/src/HDRecorderUtils.h
+++ b/src/HDRecorderUtils.h
@@ -1,0 +1,92 @@
+#pragma once
+/*
+ *  Copyright (C) 2017 Brent Murphy <bmurphy@bcmcs.net>
+ *  https://github.com/fuzzard/pvr.hdhomerun
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include <ctime>
+#include <string>
+
+#include <xbmc_pvr_types.h>
+
+#include "Utils.h"
+
+// Timer types
+#define TIMER_ONCE_MANUAL             (PVR_TIMER_TYPE_NONE + 1)
+#define TIMER_ONCE_EPG                (PVR_TIMER_TYPE_NONE + 2)
+#define TIMER_REPEATING_MANUAL        (PVR_TIMER_TYPE_NONE + 3)
+#define TIMER_REPEATING_EPG           (PVR_TIMER_TYPE_NONE + 4)
+
+struct TimerType : PVR_TIMER_TYPE
+{
+  TimerType(unsigned int id,
+            unsigned int attributes,
+            const std::string &description)
+  {
+    memset(this, 0, sizeof(PVR_TIMER_TYPE));
+    iId                              = id;
+    iAttributes                      = attributes;
+    strncpy(strDescription, description.c_str(), sizeof(strDescription) - 1);
+  }
+};
+
+typedef enum
+{
+  PVR_STREAM_NO_STREAM = 0,
+  PVR_STREAM_START_RECORDING = 1,
+  PVR_STREAM_IS_RECORDING = 2,
+  PVR_STREAM_IS_STOPPING = 3,
+  PVR_STREAM_STOPPED = 4
+} PVR_STREAM_STATUS;
+
+typedef enum
+{
+  PVR_RECORDING_FAILED = 0,
+  PVR_RECORDING_COMPLETED = 1,
+  PVR_RECORDING_INCOMPLETE = 2,
+} PVR_RECORDING_STATUS;
+
+struct PVR_REC_JOB_ENTRY
+{
+  PVR_STREAM_STATUS Status;
+  unsigned int iChannelUid; 
+  std::string strGuideNumber;
+  std::string strChannelName;
+  PVR_TIMER Timer;
+  void* ThreadPtr;
+};
+
+struct PVR_RECORDING_ENTRY
+{
+  PVR_RECORDING_STATUS Status;
+  unsigned int iRecordingId;
+  std::string strFileLocation;
+  PVR_RECORDING Recording;
+};
+
+struct RecordingStruct
+{
+  unsigned int iJobId;
+  unsigned int iChannelUid;
+  std::string strChannelName;
+  std::string strTitle;
+  time_t startTime;
+  time_t endTime;
+  int state;
+};

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -95,3 +95,26 @@ std::string EncodeURL(const std::string& strUrl)
 
   return str;
 }
+
+std::string MakeLegalFileName(const std::string &strFile)
+{
+  std::string result = strFile;
+
+  StringUtils::Replace(result, '/', '_');
+  StringUtils::Replace(result, '\\', '_');
+  StringUtils::Replace(result, '?', '_');
+
+#if defined(TARGET_WINDOWS)
+  // just filter out some illegal characters on windows
+  StringUtils::Replace(result, ':', '_');
+  StringUtils::Replace(result, '*', '_');
+  StringUtils::Replace(result, '?', '_');
+  StringUtils::Replace(result, '\"', '_');
+  StringUtils::Replace(result, '<', '_');
+  StringUtils::Replace(result, '>', '_');
+  StringUtils::Replace(result, '|', '_');
+  StringUtils::TrimRight(result, ". ");
+#endif
+
+  return result;
+}

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -50,3 +50,4 @@ int DbgPrintf(const char* szFormat, ...);
 bool GetFileContents(const std::string& url, std::string& strContent);
 
 std::string EncodeURL(const std::string& strUrl);
+std::string MakeLegalFileName(const std::string &strFile);

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -26,6 +26,7 @@
 
 #include <cstring>
 #include <string>
+
 #include <p8-platform/threads/threads.h>
 #include <p8-platform/util/util.h>
 #include <xbmc_pvr_dll.h>
@@ -94,6 +95,9 @@ ADDON_STATUS ADDON_Create(void* hdl, void* props)
 {
   if (!hdl || !props)
     return ADDON_STATUS_UNKNOWN;
+
+  PVR_PROPERTIES* pvrprops = (PVR_PROPERTIES*)props;
+  g.strUserPath = pvrprops->strUserPath;
 
   g.XBMC = new ADDON::CHelper_libXBMC_addon;
   if (!g.XBMC->RegisterMe(hdl))
@@ -259,9 +263,7 @@ const char *GetBackendHostname(void)
 
 PVR_ERROR GetDriveSpace(long long *iTotal, long long *iUsed)
 {
-  *iTotal = 1024 * 1024 * 1024;
-  *iUsed  = 0;
-  return PVR_ERROR_NO_ERROR;
+  return g.Tuners ? g.Tuners->PvrGetDriveSpace(iTotal, iUsed) : PVR_ERROR_SERVER_ERROR;
 }
 
 PVR_ERROR GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL& channel, time_t iStart, time_t iEnd)

--- a/src/client.h
+++ b/src/client.h
@@ -65,6 +65,7 @@ struct GlobalsType
   CHelper_libXBMC_pvr* PVR;
   HDRecorder* RECORDER;
   HDHomeRunTuners* Tuners;
+  std::string strUserPath;
 
   SettingsType Settings;
 };

--- a/src/client.h
+++ b/src/client.h
@@ -27,6 +27,7 @@
 #include <libXBMC_pvr.h>
 
 class HDHomeRunTuners;
+class HDRecorder;
 
 struct SettingsType
 {
@@ -36,12 +37,16 @@ struct SettingsType
     bHideDuplicateChannels = true;
     bDebug = false;
     bMarkNew = false;
+    bRecording = true;
+    strRecPath = "special://recordings/";
   }
 
   bool bHideProtected;
   bool bHideDuplicateChannels;
   bool bDebug;
   bool bMarkNew;
+  bool bRecording;
+  std::string strRecPath;
 };
 
 struct GlobalsType
@@ -52,12 +57,13 @@ struct GlobalsType
     XBMC = NULL;
     PVR = NULL;
     Tuners = NULL;
+    RECORDER = NULL;
   }
 
   ADDON_STATUS currentStatus;
   ADDON::CHelper_libXBMC_addon* XBMC;
   CHelper_libXBMC_pvr* PVR;
-
+  HDRecorder* RECORDER;
   HDHomeRunTuners* Tuners;
 
   SettingsType Settings;


### PR DESCRIPTION
Ive cobbled together a working Recorder/Timers implementation that relies on the ability to download a stream direct from a HD Homerun (https://forum.silicondust.com/forum/viewtopic.php?f=125&t=13625&sid=40982dacf49ec51d9020f7993d64a739).

Looking for comments/suggestions/code corrections to clean this up and make it a bit more robust.
Im not looking to merge at this point in time, but im hoping some other users may be able to comment on the code. Im also not sure if you would want to merge this or to leave it alone longterm.
The code was heavily based on the fork of iptvsimple by simphax (https://github.com/simphax/pvr.iptvsimple), with large adaptations to suit more modern kodi features (very limited but functioning PVR API2.0.0+ timers)

Im very much a part time hack when it comes to this, so suggestions or pointers in areas that require improvement would be greatly appreciated.

**What Works:**

- Record multiple concurrent streams. This has only been tested with a single Dual Tuner HD Homerun. Support for Multiple HD Homeruns is on the ToDo list

- EPG based timer creation, and one-time timer creation

- Selection of Recording location. Default location is set to special://recordings/. This is definable via plugin config


**ToDo:**

- Very limited Timers implementation at this point in time. I need to look at some of the other PVR Addons to get more of a grasp in how the custom timers are used and created. At the moment, Timers that are supported are manual 1 time, and EPG based selection. Eventually would like to look into Series Link, and various other custom timers that other addons support.

- Tuner selection is very 1 dimensional at the moment. Want to have the ability to search multiple tuners in the case of unavailable tuners. This will mean changing the timer cache to not hardcode to a specific TunerID for a channel.

- Error checking regarding existing recordings with same filenames. The filenames are autocreated from the EPG entries. Would like to link in episode/series numbering for entries that have this. Will need to provide options for user for how to handle existing recordings

- Tidy up shutdown procedure. Cleanup objects/threads etc.

- Other suggestions??
