### PR TITLE
contentmask and EPG_TAG updates

### DIFF
--- a/pvr.hdhomerun/addon.xml.in
+++ b/pvr.hdhomerun/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hdhomerun"
-  version="3.1.9"
+  version="3.1.10"
   name="PVR HDHomeRun Client"
   provider-name="Zoltan Csizmadia (zcsizmadia@gmail.com)">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hdhomerun/changelog.txt
+++ b/pvr.hdhomerun/changelog.txt
@@ -1,3 +1,7 @@
+v3.1.10
+- guide filters updated
+- additional epg_tag fields added
+
 v3.1.9
 - Bump jsoncpp to version 1.8.3
 - Json::CharReaderBuilder implementation

--- a/src/HDHomeRunTuners.cpp
+++ b/src/HDHomeRunTuners.cpp
@@ -323,6 +323,8 @@ PVR_ERROR HDHomeRunTuners::PvrGetEPGForChannel(ADDON_HANDLE handle, const PVR_CH
         String
           strTitle(jsonGuideItem["Title"].asString()),
           strSynopsis(jsonGuideItem["Synopsis"].asString()),
+          strEpTitle(jsonGuideItem["EpisodeTitle"].asString()),
+          strSeriesID(jsonGuideItem["SeriesID"].asString()),
           strImageURL(jsonGuideItem["ImageURL"].asString());
 
         tag.iUniqueBroadcastId = jsonGuideItem["_UID"].asUInt();
@@ -331,6 +333,8 @@ PVR_ERROR HDHomeRunTuners::PvrGetEPGForChannel(ADDON_HANDLE handle, const PVR_CH
         tag.startTime = (time_t)jsonGuideItem["StartTime"].asUInt();
         tag.endTime = (time_t)jsonGuideItem["EndTime"].asUInt();
         tag.firstAired = (time_t)jsonGuideItem["OriginalAirdate"].asUInt();
+        tag.strEpisodeName = strEpTitle.c_str();
+        tag.strSeriesLink = strSeriesID.c_str();
         tag.strPlot = strSynopsis.c_str();
         tag.strIconPath = strImageURL.c_str();
         tag.iSeriesNumber = jsonGuideItem["_SeriesNumber"].asInt();

--- a/src/HDHomeRunTuners.cpp
+++ b/src/HDHomeRunTuners.cpp
@@ -134,23 +134,26 @@ bool HDHomeRunTuners::Update(int nMode)
               unsigned int nGenreType = 0;
               for (const auto& str : jsonGuideItem["Filter"])
               {
+                if (str == "Kids")
+                  nGenreType = EPG_EVENT_CONTENTMASK_CHILDRENYOUTH;
+                else
+                if (str == "Food")
+                  nGenreType = EPG_EVENT_CONTENTMASK_LEISUREHOBBIES;
+                else
+                if (str == "Movie" || str == "Movies" ||
+                  str == "Drama")
+                  nGenreType = EPG_EVENT_CONTENTMASK_MOVIEDRAMA;
+                else
                 if (str == "News")
                   nGenreType = EPG_EVENT_CONTENTMASK_NEWSCURRENTAFFAIRS;
                 else
                 if (str == "Comedy")
                   nGenreType = EPG_EVENT_CONTENTMASK_SHOW;
                 else
-                if (str == "Movie" ||
-                  str == "Drama")
-                  nGenreType = EPG_EVENT_CONTENTMASK_MOVIEDRAMA;
-                else
-                if (str == "Food")
-                  nGenreType = EPG_EVENT_CONTENTMASK_LEISUREHOBBIES;
-                else
-                if (str == "Talk Show")
+                if (str == "Game Show")
                   nGenreType = EPG_EVENT_CONTENTMASK_SHOW;
                 else
-                if (str == "Game Show")
+                if (str == "Talk Show")
                   nGenreType = EPG_EVENT_CONTENTMASK_SHOW;
                 else
                 if (str == "Sport" ||


### PR DESCRIPTION
Updates some filter content masks. Looking to fill out a few more of the kodi standard ones, but cant find anything further on channels i receive. Will check every now and again for others.

Reordered filters to be alphabetical for the content masks, but can revert that and just add the Kids and Movies filters if desired. Intent is to fill out others if SD provides filters for any currently unused ones.