### PR TITLE
win10: fix build on UWP after #69

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,11 @@ set(PVRHDHOMERUN_HEADERS src/client.h
 if(WIN32)
   list(APPEND DEPLIBS ws2_32)
   list(APPEND DEPLIBS iphlpapi)
+  if(CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
+    # if _WIN32_WINNT isn't defined before including hdhomerun.h then 
+    # it's defined as _WIN32_WINNT_VISTA which breaks build on UWP
+    add_definitions(-D_WIN32_WINNT=0x0A00)
+  endif()
 endif()
 
 build_addon(pvr.hdhomerun PVRHDHOMERUN DEPLIBS)


### PR DESCRIPTION
seems after reordering includes after #69 the  `_WIN32_WINNT` definition became undefined and defined as `_WIN32_WINNT_VISTA` inside `hdhomerun.h` which breaks build on UWP