### PR TITLE
Minor Fixups

### DIFF
--- a/pvr.hdhomerun/addon.xml.in
+++ b/pvr.hdhomerun/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hdhomerun"
-  version="3.5.0"
+  version="3.5.1"
   name="PVR HDHomeRun Client"
   provider-name="Zoltan Csizmadia (zcsizmadia@gmail.com)">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hdhomerun/changelog.txt
+++ b/pvr.hdhomerun/changelog.txt
@@ -1,3 +1,6 @@
+v3.5.1
+- further code cleanup
+
 v3.5.0
 - Allow opening stream when multiple tuners are available
 

--- a/src/HDHomeRunTuners.cpp
+++ b/src/HDHomeRunTuners.cpp
@@ -32,8 +32,11 @@
 #include <string>
 #include <vector>
 
+#include <AddonBase.h>
+//#include <hdhomerun.h> // Cant include as it causes redefinition from inclusion in header
 #include <libXBMC_addon.h>
 #include <p8-platform/util/StringUtils.h>
+#include <xbmc_pvr_types.h>
 
 #include "client.h"
 #include "Utils.h"
@@ -44,8 +47,8 @@ static const std::string g_strGroupSDChannels("SD channels");
 
 unsigned int HDHomeRunTuners::PvrCalculateUniqueId(const std::string& str)
 {
-  int nHash = (int)std::hash<std::string>()(str);
-  return (unsigned int)abs(nHash);
+  int nHash = static_cast<int>(std::hash<std::string>()(str));
+  return static_cast<unsigned int>(abs(nHash));
 }
 
 bool HDHomeRunTuners::Update(int nMode)
@@ -70,7 +73,7 @@ bool HDHomeRunTuners::Update(int nMode)
   AutoLock l(this);
 
   // if latest discovery found fewer devices than m_Tuners List, clear and start fresh
-  if (nMode & UpdateDiscover || nTunerCount < m_Tuners.size())
+  if (nMode & UpdateDiscover || nTunerCount < static_cast<int>(m_Tuners.size()))
   {
     bClearTuners = true;
     m_Tuners.clear();

--- a/src/HDHomeRunTuners.h
+++ b/src/HDHomeRunTuners.h
@@ -26,22 +26,18 @@
 #include <string>
 #include <vector>
 
-#include "hdhomerun.h"
+#include <AddonBase.h>
+#include <hdhomerun.h>
 #include <json/json.h>
 #include <p8-platform/threads/mutex.h>
+#include <xbmc_pvr_types.h>
 
 #include "client.h"
 
 class HDHomeRunTuners
 {
-public:
-  enum
-  {
-    UpdateDiscover = 1,
-    UpdateLineUp = 2,
-    UpdateGuide = 4
-  };
 
+private:
   struct Tuner
   {
     Tuner()
@@ -62,6 +58,14 @@ public:
     ~AutoLock() { m_p->Unlock(); }
   protected:
     HDHomeRunTuners* m_p;
+  };
+
+public:
+  enum
+  {
+    UpdateDiscover = 1,
+    UpdateLineUp = 2,
+    UpdateGuide = 4
   };
 
   HDHomeRunTuners() {};

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -24,6 +24,10 @@
 
 #include "Utils.h"
 
+#if defined(TARGET_WINDOWS)
+#include <cstdio>
+#endif
+
 #include <string>
 #include <p8-platform/util/StringUtils.h>
 
@@ -57,7 +61,7 @@ bool GetFileContents(const std::string& url, std::string& strContent)
 {
   void* fileHandle = g.XBMC->OpenFile(url.c_str(), 0);
 
-  if (fileHandle == NULL)
+  if (fileHandle == nullptr)
   {
     KODI_LOG(0, "GetFileContents: %s failed\n", url.c_str());
     return false;
@@ -68,7 +72,7 @@ bool GetFileContents(const std::string& url, std::string& strContent)
 
   for (;;)
   {
-    ssize_t bytesRead = g.XBMC->ReadFile(fileHandle, buffer, sizeof(buffer));
+    int bytesRead = g.XBMC->ReadFile(fileHandle, buffer, sizeof(buffer));
     if (bytesRead <= 0)
       break;
     strContent.append(buffer, bytesRead);
@@ -88,8 +92,7 @@ std::string EncodeURL(const std::string& strUrl)
       str += c;
     else
     {
-      std::string strPercent = StringUtils::Format("%%%02X", (int)c);
-      str += strPercent;
+      str.append(StringUtils::Format("%%%02X", static_cast<int>(c)));
     }
   }
 

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -25,7 +25,9 @@
 
 #include <string>
 
-#include "client.h"
+#include <libXBMC_addon.h>
+
+extern struct GlobalsType g;
 
 #if defined(TARGET_WINDOWS) && defined(DEBUG)
 #define USE_DBG_CONSOLE

--- a/src/client.h
+++ b/src/client.h
@@ -23,10 +23,12 @@
  *
  */
 
+#include <AddonBase.h>
 #include <libXBMC_addon.h>
 #include <libXBMC_pvr.h>
 
 class HDHomeRunTuners;
+extern struct GlobalsType g;
 
 struct SettingsType
 {
@@ -57,10 +59,7 @@ struct GlobalsType
   ADDON_STATUS currentStatus;
   ADDON::CHelper_libXBMC_addon* XBMC;
   CHelper_libXBMC_pvr* PVR;
-
   HDHomeRunTuners* Tuners;
 
   SettingsType Settings;
 };
-
-extern GlobalsType g;


### PR DESCRIPTION
~~Bump from jsoncpp 1.8.3 to 1.8.4. This removes 106 warnings from an appveyor build (windows) all related to inappropriate jsoncpp deprecation warnings. No other changes in the 1.8.4 tag affect pvr.hdhomerun (or any other kodi addon that uses jsoncpp). There is no change to a build on mac/linux platforms.~~

All other changes were minors ive held off on pushing because they dont really affect anything.
Further header definition cleanup, rename of a function to adhere to kodi code guidelines, some more changes to c++11 casts. 

ssize_t is a definition made by kodi, that just defines it as an int. https://codedocs.xyz/xbmc/xbmc/config_8h.html#a8af93bbb66534e14d651bbb0638ee796
Ive just removed the typedef used in here to make things clearer in the long run.

One thing to note is the comment out of the inclusion of hdhomerun.h. libhdhomerun doesnt have any inclusion guards or use pragma once, so it can only be included once in a project. Ive sent a PR to silicondust that implements a header guard, but not sure if it will ever be merged.

If there are any questions about anything, let me know and i can clarify. 
  