### PR TITLE
add menuhooks to force a guide/device refresh

### DIFF
--- a/pvr.hdhomerun/addon.xml.in
+++ b/pvr.hdhomerun/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hdhomerun"
-  version="3.4.3"
+  version="3.4.4"
   name="PVR HDHomeRun Client"
   provider-name="Zoltan Csizmadia (zcsizmadia@gmail.com)">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hdhomerun/changelog.txt
+++ b/pvr.hdhomerun/changelog.txt
@@ -1,3 +1,6 @@
+v3.4.4
+- Add menuhooks for device and guide refresh by user
+
 v3.4.1
 - Update to PVR API v5.10.1
 

--- a/pvr.hdhomerun/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.hdhomerun/resources/language/resource.language.en_gb/strings.po
@@ -35,3 +35,19 @@ msgstr ""
 msgctxt "#32005"
 msgid "Mark new show"
 msgstr ""
+
+msgctxt "#32101"
+msgid "Refresh Guide Data"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Refresh HDHomerun device list"
+msgstr ""
+
+msgctxt "#32111"
+msgid "Guide Data is refreshing"
+msgstr ""
+
+msgctxt "#32112"
+msgid "Refresh HD Homerun Devices started"
+msgstr ""

--- a/src/HDHomeRunTuners.cpp
+++ b/src/HDHomeRunTuners.cpp
@@ -408,6 +408,18 @@ PVR_ERROR HDHomeRunTuners::PvrGetChannelGroupMembers(ADDON_HANDLE handle, const 
   return PVR_ERROR_NO_ERROR;
 }
 
+void HDHomeRunTuners::TriggerEPGUpdate()
+{
+  AutoLock l(this);
+
+  KODI_LOG(ADDON::LOG_DEBUG, "Trigger EPG Update All Channels");
+
+  for (const auto& iterTuner : m_Tuners)
+    for (const auto& jsonChannel : iterTuner.LineUp)
+      g.PVR->TriggerEpgUpdate(jsonChannel["_UID"].asUInt());
+
+}
+
 std::string HDHomeRunTuners::_GetChannelStreamURL(int iUniqueId)
 {
   AutoLock l(this);

--- a/src/HDHomeRunTuners.h
+++ b/src/HDHomeRunTuners.h
@@ -76,6 +76,7 @@ public:
   PVR_ERROR PvrGetChannelGroups(ADDON_HANDLE handle, bool bRadio);
   PVR_ERROR PvrGetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &group);
   std::string _GetChannelStreamURL(int iUniqueId);
+  void TriggerEPGUpdate();
 
 private:
   unsigned int PvrCalculateUniqueId(const std::string& str);


### PR DESCRIPTION
Allows user to force a guide refresh, as well as a full device search refresh which
allows discovery of hdhomerun devices without restarting the addon.