### PR TITLE
[cmake] remove usage of kodi-platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,19 +7,16 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 enable_language(CXX)
 
 find_package(Kodi REQUIRED)
-find_package(kodiplatform REQUIRED)
 find_package(p8-platform REQUIRED)
 find_package(JsonCpp REQUIRED)
 find_package(hdhomerun REQUIRED)
 
-include_directories(${kodiplatform_INCLUDE_DIRS}
-                    ${p8-platform_INCLUDE_DIRS}
+include_directories(${p8-platform_INCLUDE_DIRS}
                     ${KODI_INCLUDE_DIR}
                     ${JSONCPP_INCLUDE_DIRS}
                     ${HDHOMERUN_INCLUDE_DIRS})
 
-set(DEPLIBS ${kodiplatform_LIBRARIES}
-            ${p8-platform_LIBRARIES}
+set(DEPLIBS ${p8-platform_LIBRARIES}
             ${JSONCPP_LIBRARIES}
             ${HDHOMERUN_LIBRARIES})
 

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: kodi-pvr-hdhomerun
 Priority: extra
 Maintainer: Nobody <nobody@kodi.tv>
-Build-Depends: debhelper (>= 9.0.0), cmake, libkodiplatform-dev (>= 16.0.0),
+Build-Depends: debhelper (>= 9.0.0), cmake, libp8-platform-dev,
                kodi-addon-dev, libhdhomerun-dev (>= 20150826), libjsoncpp-dev
 Standards-Version: 3.9.5
 Section: libs


### PR DESCRIPTION
The pvr.hdhomerun binary addon does not use kodi-platform.
Remove existing references from CMakeLists.txt and debian/control.