### PR TITLE
Add support for HDHomeRun DVR Recorded TV support

### DIFF
--- a/src/HDHomeRunTuners.h
+++ b/src/HDHomeRunTuners.h
@@ -39,7 +39,8 @@ public:
   {
     UpdateDiscover = 1,
     UpdateLineUp = 2,
-    UpdateGuide = 4
+    UpdateGuide = 4,
+    UpdateRecordings = 8
   };
 
   struct Tuner
@@ -52,6 +53,7 @@ public:
     hdhomerun_discover_device_t Device;
     Json::Value LineUp;
     Json::Value Guide;
+    Json::Value Recordings;
   };
 
   class AutoLock
@@ -68,7 +70,7 @@ public:
   void Lock() { m_Lock.Lock(); }
   void Unlock() { m_Lock.Unlock(); }
 
-  bool Update(int nMode = UpdateDiscover | UpdateLineUp | UpdateGuide);
+  bool Update(int nMode = UpdateDiscover | UpdateLineUp | UpdateGuide | UpdateRecordings);
   PVR_ERROR PvrGetChannels(ADDON_HANDLE handle, bool bRadio);
   int PvrGetChannelsAmount();
   PVR_ERROR PvrGetEPGForChannel(ADDON_HANDLE handle, int iChannelUid, time_t iStart, time_t iEnd);
@@ -76,6 +78,9 @@ public:
   PVR_ERROR PvrGetChannelGroups(ADDON_HANDLE handle, bool bRadio);
   PVR_ERROR PvrGetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &group);
   std::string GetChannelStreamURL(const PVR_CHANNEL* channel);
+  PVR_ERROR PvrGetRecordings(ADDON_HANDLE handle, bool deleted);
+  int PvrGetRecordingsAmount(bool deleted);
+  std::string GetRecordingStreamURL(const PVR_RECORDING* recording);
 
 private:
   unsigned int PvrCalculateUniqueId(const std::string& str);


### PR DESCRIPTION
This PR adds some basic support for the HDHomeRun DVR devices (NAS, Servio, Scribe, etc) in the form of being able to access and play back any Recorded TV programs available on those device(s).

I think this is best treated as a Proof of Concept that pvr.hdhomerun can be extended to support the DVR services without too much hassle.  Not all possible 'features' for the storage engine, like available disk space, were implemented here so as little of the existing code would need to be changed.

Note that in testing I ran into a problem that I believe is unrelated, when starting a recording seeking on that recording may hang with a "100" buffering circle.  I see this in my addon as well when I am not properly implementing GetStreamTimes(), which shouldn't be necessary when the addon isn't handling the input stream.  I was able to work around the problem by seeking to near the end of a recording first, then it behaved normally for all recordings until I restarted Kodi.  I can investigate further if the reviewers/maintainers disagree with that assessment.

I did my best to reuse the existing code and logic to not make the changes look completely foreign.

Thanks!
