### PR TITLE
pvr.hdhomerun updates

### DIFF
--- a/depends/common/hdhomerun/hdhomerun.txt
+++ b/depends/common/hdhomerun/hdhomerun.txt
@@ -1,1 +1,1 @@
-hdhomerun https://github.com/Silicondust/libhdhomerun/archive/0d3b72c1ccf1502a73c7f413e7d3382d9ee732c6.tar.gz
+hdhomerun https://github.com/Silicondust/libhdhomerun/archive/64aa1606b58e9654385333031c5d7bf02989bf49.tar.gz

--- a/pvr.hdhomerun/addon.xml.in
+++ b/pvr.hdhomerun/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hdhomerun"
-  version="4.1.2"
+  version="4.1.3"
   name="PVR HDHomeRun Client"
   provider-name="Zoltan Csizmadia (zcsizmadia@gmail.com)">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hdhomerun/changelog.txt
+++ b/pvr.hdhomerun/changelog.txt
@@ -1,3 +1,7 @@
+v4.1.3
+- Update libhdhomerun dependency to v20200303
+- Fix accuracy of EPG 'Program Information' Orignal Air Date values
+
 v4.1.2
 - Update PVR API 6.2.0
 

--- a/src/HDHomeRunTuners.cpp
+++ b/src/HDHomeRunTuners.cpp
@@ -298,7 +298,7 @@ namespace
 
 std::string ParseAsW3CDateString(time_t time)
 {
-  std::tm* tm = std::localtime(&time);
+  std::tm* tm = std::gmtime(&time);
   char buffer[16];
   std::strftime(buffer, 16, "%Y-%m-%d", tm);
 


### PR DESCRIPTION
This PR attempts to update pvr.hdhomerun to resolve a minor concern noted during local testing:

- Update libhdhomerun to v20200303
- Fix accuracy of EPG Program Information 'Orignal Air Date' value

PVR API 6.2.0 changed how Original Air Date is to be reported.  The HDHomeRun backend provides this value as a UTC Unix epoch "date".  Using localtime() will adjust this date left if the user's system is West of Greenwich, England.  The proposed change indicates that the supplied epoch is GMT, which should correct it for all users.
