### PR TITLE
Remove p8platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,17 +4,14 @@ project(pvr.hdhomerun)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 
 find_package(Kodi REQUIRED)
-find_package(p8-platform REQUIRED)
 find_package(JsonCpp REQUIRED)
 find_package(hdhomerun REQUIRED)
 
-include_directories(${p8-platform_INCLUDE_DIRS}
-                    ${KODI_INCLUDE_DIR}/.. # Hack way with "/..", need bigger Kodi cmake rework to match right include ways
+include_directories(${KODI_INCLUDE_DIR}/.. # Hack way with "/..", need bigger Kodi cmake rework to match right include ways
                     ${JSONCPP_INCLUDE_DIRS}
                     ${HDHOMERUN_INCLUDE_DIRS})
 
-set(DEPLIBS ${p8-platform_LIBRARIES}
-            ${JSONCPP_LIBRARIES}
+set(DEPLIBS ${JSONCPP_LIBRARIES}
             ${HDHOMERUN_LIBRARIES})
 
 set(PVRHDHOMERUN_SOURCES src/HDHomeRunTuners.cpp

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: kodi-pvr-hdhomerun
 Priority: extra
 Maintainer: Nobody <nobody@kodi.tv>
-Build-Depends: debhelper (>= 9.0.0), cmake, libp8-platform-dev,
+Build-Depends: debhelper (>= 9.0.0), cmake,
                kodi-addon-dev, libhdhomerun-dev (>= 20150826), libjsoncpp-dev
 Standards-Version: 4.1.2
 Section: libs

--- a/depends/common/p8-platform/p8-platform.txt
+++ b/depends/common/p8-platform/p8-platform.txt
@@ -1,1 +1,0 @@
-p8-platform https://github.com/xbmc/platform.git cee64e9dc0b69e8d286dc170a78effaabfa09c44

--- a/depends/windowsstore/p8-platform/p8-platform.txt
+++ b/depends/windowsstore/p8-platform/p8-platform.txt
@@ -1,1 +1,0 @@
-p8-platform https://github.com/afedchin/platform.git win10

--- a/pvr.hdhomerun/addon.xml.in
+++ b/pvr.hdhomerun/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hdhomerun"
-  version="6.0.0"
+  version="6.0.1"
   name="PVR HDHomeRun Client"
   provider-name="Zoltan Csizmadia (zcsizmadia@gmail.com)">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hdhomerun/changelog.txt
+++ b/pvr.hdhomerun/changelog.txt
@@ -1,3 +1,9 @@
+v6.0.1:
+- Remove dependency on p8-platform
+- Update to use std::thread
+- Update to use std::mutex
+- Use kodi StringUtils
+
 v6.0.0:
 - Update PVR API 7.0.0
 - Rework addon to support new API interface
@@ -150,7 +156,7 @@ v2.1.0
 
 v2.0.2
 - Updated to PVR API v4.2.0
- 
+
 v2.0.1
 - Updated language files from Transifex
 

--- a/src/HDHomeRunTuners.cpp
+++ b/src/HDHomeRunTuners.cpp
@@ -11,8 +11,8 @@
 #include "Utils.h"
 
 #include <kodi/Filesystem.h>
+#include <kodi/tools/StringUtils.h>
 #include <set>
-#include <p8-platform/util/StringUtils.h>
 
 static const std::string g_strGroupFavoriteChannels("Favorite channels");
 static const std::string g_strGroupHDChannels("HD channels");
@@ -177,7 +177,7 @@ bool HDHomeRunTuners::Update(int nMode)
     //
     if (nMode & UpdateGuide)
     {
-      strUrl = StringUtils::Format("http://my.hdhomerun.com/api/guide.php?DeviceAuth=%s", EncodeURL(pTuner->Device.device_auth).c_str());
+      strUrl = kodi::tools::StringUtils::Format("http://my.hdhomerun.com/api/guide.php?DeviceAuth=%s", EncodeURL(pTuner->Device.device_auth).c_str());
       KODI_LOG(ADDON_LOG_DEBUG, "Requesting HDHomeRun guide: %s", strUrl.c_str());
 
       if (GetFileContents(strUrl.c_str(), strJson))
@@ -251,7 +251,7 @@ bool HDHomeRunTuners::Update(int nMode)
     //
     if (nMode & UpdateLineUp)
     {
-      strUrl = StringUtils::Format("%s/lineup.json", pTuner->Device.base_url);
+      strUrl = kodi::tools::StringUtils::Format("%s/lineup.json", pTuner->Device.base_url);
 
       KODI_LOG(ADDON_LOG_DEBUG, "Requesting HDHomeRun lineup: %s", strUrl.c_str());
 

--- a/src/HDHomeRunTuners.h
+++ b/src/HDHomeRunTuners.h
@@ -9,20 +9,19 @@
 
 #pragma once
 
+#include <atomic>
 #include <mutex>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "hdhomerun.h"
 #include <json/json.h>
 #include <kodi/addon-instance/PVR.h>
-#include <p8-platform/threads/threads.h>
 
 class ATTRIBUTE_HIDDEN HDHomeRunTuners
   : public kodi::addon::CAddonBase,
-    public kodi::addon::CInstancePVRClient,
-    public P8PLATFORM::CThread
-
+    public kodi::addon::CInstancePVRClient
 {
 public:
   enum
@@ -82,12 +81,14 @@ public:
   PVR_ERROR GetChannelGroupMembers(const kodi::addon::PVRChannelGroup& group, kodi::addon::PVRChannelGroupMembersResultSet& results) override;
 
 protected:
-  void *Process() override;
+  void Process();
 
 private:
   std::string GetChannelStreamURL(const kodi::addon::PVRChannel& channel);
 
   unsigned int PvrCalculateUniqueId(const std::string& str);
   std::vector<Tuner> m_Tuners;
+  std::atomic<bool> m_running = {false};
+  std::thread m_thread;
   std::mutex m_Lock;
 };

--- a/src/HDHomeRunTuners.h
+++ b/src/HDHomeRunTuners.h
@@ -9,13 +9,13 @@
 
 #pragma once
 
+#include <mutex>
 #include <string>
 #include <vector>
 
 #include "hdhomerun.h"
 #include <json/json.h>
 #include <kodi/addon-instance/PVR.h>
-#include <p8-platform/threads/mutex.h>
 #include <p8-platform/threads/threads.h>
 
 class ATTRIBUTE_HIDDEN HDHomeRunTuners
@@ -57,8 +57,8 @@ public:
   HDHomeRunTuners() = default;
   ~HDHomeRunTuners() override;
 
-  void Lock() { m_Lock.Lock(); }
-  void Unlock() { m_Lock.Unlock(); }
+  void Lock() { m_Lock.lock(); }
+  void Unlock() { m_Lock.unlock(); }
 
   ADDON_STATUS Create() override;
   ADDON_STATUS SetSetting(const std::string& settingName, const kodi::CSettingValue& settingValue) override;
@@ -89,5 +89,5 @@ private:
 
   unsigned int PvrCalculateUniqueId(const std::string& str);
   std::vector<Tuner> m_Tuners;
-  P8PLATFORM::CMutex m_Lock;
+  std::mutex m_Lock;
 };

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -10,8 +10,8 @@
 #include "Utils.h"
 
 #include <kodi/Filesystem.h>
+#include <kodi/tools/StringUtils.h>
 #include <string>
-#include <p8-platform/util/StringUtils.h>
 
 #if defined(USE_DBG_CONSOLE) && defined(TARGET_WINDOWS)
 int DbgPrintf(const char* szFormat, ...)
@@ -70,7 +70,7 @@ std::string EncodeURL(const std::string& strUrl)
       str += c;
     else
     {
-      std::string strPercent = StringUtils::Format("%%%02X", (int)c);
+      std::string strPercent = kodi::tools::StringUtils::Format("%%%02X", (int)c);
       str += strPercent;
     }
   }


### PR DESCRIPTION
v6.0.1:
- Remove dependency on p8-platform
- Update to use std::thread
- Update to use std::mutex
- Use kodi StringUtils
