### PR TITLE
[Nexus] initial release change for new Kodi 20 Nexus version

### DIFF
--- a/.github/workflows/changelog-and-release.yml
+++ b/.github/workflows/changelog-and-release.yml
@@ -133,7 +133,7 @@ jobs:
         shell: bash
 
       # Create a release at {steps.required-variables.outputs.branch}
-      # - tag and release name format: {steps.required-variables.outputs.version}-{steps.required-variables.outputs.branch} ie. 1.0.0-Matrix
+      # - tag and release name format: {steps.required-variables.outputs.version}-{steps.required-variables.outputs.branch} ie. 20.0.0-Nexus
       # - release body: {steps.required-variables.outputs.changes}
       - name: Create Release
         id: create-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         working-directory: ${{ github.event.repository.name }}
 
       # Create a release at {steps.required-variables.outputs.branch}
-      # - tag and release name format: {steps.required-variables.outputs.version}-{steps.required-variables.outputs.branch} ie. 1.0.0-Matrix
+      # - tag and release name format: {steps.required-variables.outputs.version}-{steps.required-variables.outputs.branch} ie. 20.0.0-Nexus
       # - release body: {steps.required-variables.outputs.changes}
       - name: Create Release
         id: create-release

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(version: "Matrix")
+buildPlugin(version: "Nexus")

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
-[![Build and run tests](https://github.com/kodi-pvr/pvr.hdhomerun/actions/workflows/build.yml/badge.svg?branch=Matrix)](https://github.com/kodi-pvr/pvr.hdhomerun/actions/workflows/build.yml)
-[![Build Status](https://dev.azure.com/teamkodi/kodi-pvr/_apis/build/status/kodi-pvr.pvr.hdhomerun?branchName=Matrix)](https://dev.azure.com/teamkodi/kodi-pvr/_build/latest?definitionId=61&branchName=Matrix)
-[![Build Status](https://jenkins.kodi.tv/view/Addons/job/kodi-pvr/job/pvr.hdhomerun/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/kodi-pvr%2Fpvr.hdhomerun/branches/)
+[![Build and run tests](https://github.com/kodi-pvr/pvr.hdhomerun/actions/workflows/build.yml/badge.svg?branch=Nexus)](https://github.com/kodi-pvr/pvr.hdhomerun/actions/workflows/build.yml)
+[![Build Status](https://dev.azure.com/teamkodi/kodi-pvr/_apis/build/status/kodi-pvr.pvr.hdhomerun?branchName=Nexus)](https://dev.azure.com/teamkodi/kodi-pvr/_build/latest?definitionId=61&branchName=Nexus)
+[![Build Status](https://jenkins.kodi.tv/view/Addons/job/kodi-pvr/job/pvr.hdhomerun/job/Nexus/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/kodi-pvr%2Fpvr.hdhomerun/branches/)
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/5120/badge.svg)](https://scan.coverity.com/projects/5120)
 
 # HDHomeRun PVR
@@ -12,8 +12,8 @@ HDHomeRun PVR client addon for [Kodi](https://kodi.tv)
 
 ### Linux
 
-1. `git clone --branch Matrix https://github.com/xbmc/xbmc.git`
-2. `git clone https://github.com/kodi-pvr/pvr.hdhomerun.git`
+1. `git clone --branch master https://github.com/xbmc/xbmc.git`
+2. `git clone --branch Nexus https://github.com/kodi-pvr/pvr.hdhomerun.git`
 3. `cd pvr.hdhomerun && mkdir build && cd build`
 4. `cmake -DADDONS_TO_BUILD=pvr.hdhomerun -DADDON_SRC_PREFIX=../.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../../xbmc/addons -DPACKAGE_ZIP=1 ../../xbmc/cmake/addons`
 5. `make`

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,7 @@ trigger:
   branches:
     include:
     - Matrix
+    - Nexus
     - releases/*
   paths:
     include:

--- a/pvr.hdhomerun/addon.xml.in
+++ b/pvr.hdhomerun/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hdhomerun"
-  version="7.1.1"
+  version="20.0.0"
   name="PVR HDHomeRun Client"
   provider-name="Zoltan Csizmadia (zcsizmadia@gmail.com)">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hdhomerun/changelog.txt
+++ b/pvr.hdhomerun/changelog.txt
@@ -1,3 +1,13 @@
+v20.0.0
+- Translations updates from Weblate
+  - da_dk
+- Updated hdhomerun on depends to release 20201023
+- Updated jsoncpp on depends to version 1.9.4
+- Changed test builds to 'Kodi 20 Nexus'
+- Increased version to 20.0.0
+  - With start of Kodi 20 Nexus, takes addon as major the same version number as Kodi.
+    This done to know easier to which Kodi the addon works.
+
 v7.1.1
 - Language update from Weblate
 


### PR DESCRIPTION
This change the builds to Kodi Nexus.

Further is the version to 20.0.0 increased to have equal to Kodi and to see on which Version this addon works.