### PR TITLE
[Nexus] Add supports recordings delete capability for PVR API 8.0.0

### DIFF
--- a/pvr.hdhomerun/addon.xml.in
+++ b/pvr.hdhomerun/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hdhomerun"
-  version="20.0.0"
+  version="20.1.0"
   name="PVR HDHomeRun Client"
   provider-name="Zoltan Csizmadia (zcsizmadia@gmail.com)">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hdhomerun/changelog.txt
+++ b/pvr.hdhomerun/changelog.txt
@@ -1,3 +1,8 @@
+v20.1.0
+- Kodi API to 8.0.0
+  - Add supports recordings delete capability
+  - Enforce EDL limits
+
 v20.0.0
 - Translations updates from Weblate
   - da_dk

--- a/src/HDHomeRunTuners.cpp
+++ b/src/HDHomeRunTuners.cpp
@@ -74,6 +74,7 @@ PVR_ERROR HDHomeRunTuners::GetCapabilities(kodi::addon::PVRCapabilities& capabil
   capabilities.SetSupportsRadio(false);
   capabilities.SetSupportsChannelGroups(true);
   capabilities.SetSupportsRecordings(false);
+  capabilities.SetSupportsRecordingsDelete(false);
   capabilities.SetSupportsRecordingsUndelete(false);
   capabilities.SetSupportsTimers(false);
   capabilities.SetSupportsRecordingsRename(false);


### PR DESCRIPTION
- Kodi API to 8.0.0
  - Add supports recordings delete capability
  - Enforce EDL limits

This PR should be rebuilt via Jenkins after these xbmc PRs are merged:
- https://github.com/xbmc/xbmc/pull/20009
- https://github.com/xbmc/xbmc/pull/19395