### PR TITLE
Add setting to use HTTP-based tuner discovery

### DIFF
--- a/pvr.hdhomerun/addon.xml.in
+++ b/pvr.hdhomerun/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hdhomerun"
-  version="20.2.1"
+  version="20.3.0"
   name="HDHomeRun Client"
   provider-name="Zoltan Csizmadia (zcsizmadia@gmail.com)">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hdhomerun/changelog.txt
+++ b/pvr.hdhomerun/changelog.txt
@@ -1,3 +1,6 @@
+v20.3.0
+- Add Use HTTP discovery setting
+
 v20.2.1
 - Change name to make add-on easier to find in UI
 

--- a/pvr.hdhomerun/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.hdhomerun/resources/language/resource.language.en_gb/strings.po
@@ -43,3 +43,7 @@ msgstr ""
 msgctxt "#32005"
 msgid "Mark new show"
 msgstr ""
+
+msgctxt "#32006"
+msgid "Use HTTP discovery"
+msgstr ""

--- a/pvr.hdhomerun/resources/settings.xml
+++ b/pvr.hdhomerun/resources/settings.xml
@@ -23,6 +23,11 @@
           <default>true</default>
           <control type="toggle"/>
         </setting>
+        <setting id="http_discovery" type="boolean" label="32006">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle"/>
+        </setting>
       </group>
     </category>
   </section>

--- a/src/HDHomeRunTuners.cpp
+++ b/src/HDHomeRunTuners.cpp
@@ -116,13 +116,69 @@ PVR_ERROR HDHomeRunTuners::OnSystemWake()
   return PVR_ERROR_NO_ERROR;
 }
 
+int HDHomeRunTuners::DiscoverTunersViaHttp(struct hdhomerun_discover_device_t* tuners,
+                                           int maxtuners)
+{
+  int numtuners = 0;
+
+  std::string strJson, jsonReaderError;
+  Json::CharReaderBuilder jsonReaderBuilder;
+  std::unique_ptr<Json::CharReader> const jsonReader(jsonReaderBuilder.newCharReader());
+
+  // This API may be removed by the provider in the future without notice; treat an inability
+  // to access this URL as if there were no tuners discovered.  Update() will then attempt
+  // a normal broadcast discovery and try to find the user's tuner devices that way
+  if (GetFileContents("https://api.hdhomerun.com/discover", strJson))
+  {
+    Json::Value devices;
+    if (jsonReader->parse(strJson.c_str(), strJson.c_str() + strJson.size(), &devices,
+                          &jsonReaderError) &&
+        devices.type() == Json::arrayValue)
+    {
+      for (const auto& device : devices)
+      {
+        // Tuners are identified by the presence of a DeviceID value in the JSON;
+        // this also applies to devices that have both tuners and a storage engine (DVR)
+        if (!device["DeviceID"].isNull() && !device["LocalIP"].isNull())
+        {
+          std::string ipstring = device["LocalIP"].asString();
+          if (ipstring.length() > 0)
+          {
+            uint32_t ip = ntohl(inet_addr(ipstring.c_str()));
+            numtuners += hdhomerun_discover_find_devices_custom_v2(
+                ip, HDHOMERUN_DEVICE_TYPE_TUNER, HDHOMERUN_DEVICE_ID_WILDCARD, &tuners[numtuners],
+                maxtuners - numtuners);
+          }
+        }
+
+        if (numtuners == maxtuners)
+          break;
+      }
+    }
+  }
+
+  return numtuners;
+}
+
 bool HDHomeRunTuners::Update(int nMode)
 {
   //
   // Discover
   //
   struct hdhomerun_discover_device_t foundDevices[16] = {};
-  int nTunerCount = hdhomerun_discover_find_devices_custom_v2(0, HDHOMERUN_DEVICE_TYPE_TUNER, HDHOMERUN_DEVICE_ID_WILDCARD, foundDevices, 16);
+  int nTunerCount = 0;
+
+  // Attempt tuner discovery via HTTP first if the user has it enabled.  The provider may
+  // remove the ability for this method to work in the future without notice, so ensure
+  // that normal discovery is treated as a fall-through case rather than making these
+  // methods mutually exclusive
+
+  if (SettingsType::Get().GetHttpDiscovery())
+    nTunerCount = DiscoverTunersViaHttp(foundDevices, 16);
+
+  if (nTunerCount <= 0)
+    nTunerCount = hdhomerun_discover_find_devices_custom_v2(
+        0, HDHOMERUN_DEVICE_TYPE_TUNER, HDHOMERUN_DEVICE_ID_WILDCARD, foundDevices, 16);
 
   if (nTunerCount <= 0)
     return false;

--- a/src/HDHomeRunTuners.h
+++ b/src/HDHomeRunTuners.h
@@ -87,6 +87,9 @@ private:
   std::string GetChannelStreamURL(const kodi::addon::PVRChannel& channel);
 
   unsigned int PvrCalculateUniqueId(const std::string& str);
+
+  int DiscoverTunersViaHttp(struct hdhomerun_discover_device_t* tuners, int maxtuners);
+
   std::vector<Tuner> m_Tuners;
   std::atomic<bool> m_running = {false};
   std::thread m_thread;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -21,6 +21,7 @@ bool SettingsType::ReadSettings()
   bHideDuplicateChannels = kodi::addon::GetSettingBoolean("hide_duplicate", true);
   bMarkNew = kodi::addon::GetSettingBoolean("mark_new", true);
   bDebug = kodi::addon::GetSettingBoolean("debug", false);
+  bHttpDiscovery = kodi::addon::GetSettingBoolean("http_discovery", false);
 
   return true;
 }
@@ -42,6 +43,11 @@ ADDON_STATUS SettingsType::SetSetting(const std::string& settingName,
     bMarkNew = settingValue.GetBoolean();
   else if (settingName == "debug")
     bDebug = settingValue.GetBoolean();
+  else if (settingName == "http_discovery")
+  {
+    bHttpDiscovery = settingValue.GetBoolean();
+    return ADDON_STATUS_NEED_RESTART;
+  }
 
   return ADDON_STATUS_OK;
 }

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -23,6 +23,7 @@ public:
   bool GetHideDuplicateChannels() const { return bHideDuplicateChannels; }
   bool GetDebug() const { return bDebug; }
   bool GetMarkNew() const { return bMarkNew; }
+  bool GetHttpDiscovery() const { return bHttpDiscovery; }
 
 private:
   SettingsType() = default;
@@ -31,4 +32,5 @@ private:
   bool bHideDuplicateChannels = true;
   bool bDebug = false;
   bool bMarkNew = false;
+  bool bHttpDiscovery = false;
 };


### PR DESCRIPTION
Refers to Issue https://github.com/kodi-pvr/pvr.hdhomerun/issues/116 - "Use ip address instead of device discovery"

This Pull Request adds a new setting to the addon that allows users to opt into using the SiliconDust API "HTTP Discovery" (at least that's what I've always it) to find their tuner devices.  The normal UDP broadcast discovery doesn't work when the tuner(s) are on a different subnet than the client.

The HTTP discovery data can become "stale", as any device the user had turned on and connected will stay in this list for up to 24 hours after it's been turned off or disconnected.  As such, the only data points used from the API are "DeviceID", which indicates the device has tuners and "LocalIP".  The LocalIP address is used to then contact the device and gather the discovery information normally via libhdhomerun.  This allows stale devices to be ignored.

If no devices are found via HTTP, there is a fallback to try UDP discovery as well.  I felt this important since this API might disappear in the future.

Please let me know what you think or any edits that need to be made, happy to oblige.

I only added the setting string to en_gb, this is correct and it will be translated automatically at some point, yes?