### PR TITLE
Allow user to set specific IP of hdhomerun unit

### DIFF
--- a/pvr.hdhomerun/addon.xml.in
+++ b/pvr.hdhomerun/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hdhomerun"
-  version="20.4.0"
+  version="20.5.0"
   name="HDHomeRun Client"
   provider-name="Zoltan Csizmadia (zcsizmadia@gmail.com)">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hdhomerun/changelog.txt
+++ b/pvr.hdhomerun/changelog.txt
@@ -1,3 +1,7 @@
+v20.5.0
+- Add some help labels to some settings and group discovery related settings
+- Allow a user to specifically set IP address of HDHomerun device to search for if other discovery methods dont work.
+
 v20.4.0
 - Kodi inputstream API update to version 3.2.0
 - Kodi PVR API update to version 8.0.2

--- a/pvr.hdhomerun/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.hdhomerun/resources/language/resource.language.en_gb/strings.po
@@ -47,3 +47,7 @@ msgstr ""
 msgctxt "#32006"
 msgid "Use HTTP discovery"
 msgstr ""
+
+msgctxt "#32007"
+msgid "Set IP of device to use"
+msgstr ""

--- a/pvr.hdhomerun/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.hdhomerun/resources/language/resource.language.en_gb/strings.po
@@ -24,6 +24,7 @@ msgctxt "Addon Description"
 msgid "HDHomeRun PVR Client"
 msgstr ""
 
+#. label-category: general
 msgctxt "#32001"
 msgid "General"
 msgstr ""
@@ -44,10 +45,35 @@ msgctxt "#32005"
 msgid "Mark new show"
 msgstr ""
 
+#. label: Device Discovery - http_discovery
 msgctxt "#32006"
 msgid "Use HTTP discovery"
 msgstr ""
 
+#. label: Device Discovery - force_ip
 msgctxt "#32007"
 msgid "Set IP of device to use"
+msgstr ""
+
+#. label-group: General - Device Discovery
+msgctxt "#32008"
+msgid "Device Discovery"
+msgstr ""
+
+#empty strings from id 32009 to 320099
+
+#. ############
+#. help info #
+#. ############
+
+#. help info - General
+
+#. help: Device Discovery - http_discovery
+msgctxt "#32100"
+msgid "This uses Silicondust web API to return HDHomeRun devices connected with the same internet IP address"
+msgstr ""
+
+#. help: Device Discovery - force_ip
+msgctxt "#32101"
+msgid "When other discovery methods do not work, enter an [B]IPv4[/B] address of a HDHomeRun device to explicitly search only that IP. This works when Broadcast and HTTP discovery do not find devices due to LAN/WAN differences in Client/Tuner. Restart Addon by Disabling and Enabling when changed."
 msgstr ""

--- a/pvr.hdhomerun/resources/settings.xml
+++ b/pvr.hdhomerun/resources/settings.xml
@@ -23,12 +23,14 @@
           <default>true</default>
           <control type="toggle"/>
         </setting>
-        <setting id="http_discovery" type="boolean" label="32006">
+      </group>
+      <group id="2" label="32008">
+        <setting id="http_discovery" type="boolean" label="32006" help="32100">
           <level>0</level>
           <default>false</default>
           <control type="toggle"/>
         </setting>
-        <setting id="force_ip" type="string" label="32007">
+        <setting id="force_ip" type="string" label="32007" help="32101">
           <level>0</level>
           <default></default>
           <constraints>

--- a/pvr.hdhomerun/resources/settings.xml
+++ b/pvr.hdhomerun/resources/settings.xml
@@ -28,6 +28,14 @@
           <default>false</default>
           <control type="toggle"/>
         </setting>
+        <setting id="force_ip" type="string" label="32007">
+          <level>0</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string" />
+        </setting>
       </group>
     </category>
   </section>

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -22,6 +22,7 @@ bool SettingsType::ReadSettings()
   bMarkNew = kodi::addon::GetSettingBoolean("mark_new", true);
   bDebug = kodi::addon::GetSettingBoolean("debug", false);
   bHttpDiscovery = kodi::addon::GetSettingBoolean("http_discovery", false);
+  strForcedIP = kodi::addon::GetSettingString("force_ip", "");
 
   return true;
 }
@@ -46,6 +47,11 @@ ADDON_STATUS SettingsType::SetSetting(const std::string& settingName,
   else if (settingName == "http_discovery")
   {
     bHttpDiscovery = settingValue.GetBoolean();
+    return ADDON_STATUS_NEED_RESTART;
+  }
+  else if (settingName == "force_ip")
+  {
+    strForcedIP = settingValue.GetString();
     return ADDON_STATUS_NEED_RESTART;
   }
 

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <string>
+
 #include <kodi/AddonBase.h>
 
 class ATTR_DLL_LOCAL SettingsType
@@ -24,6 +26,7 @@ public:
   bool GetDebug() const { return bDebug; }
   bool GetMarkNew() const { return bMarkNew; }
   bool GetHttpDiscovery() const { return bHttpDiscovery; }
+  std::string GetForcedIP() const { return strForcedIP; }
 
 private:
   SettingsType() = default;
@@ -33,4 +36,5 @@ private:
   bool bDebug = false;
   bool bMarkNew = false;
   bool bHttpDiscovery = false;
+  std::string strForcedIP;
 };


### PR DESCRIPTION
Im away from home and had a need to watch tv from my hdhomeruns located at home. Im connected via a vpn, so the "normal" discovery methods dont work. no broadcast searches, and the HTTP discovery API doesnt return anything as the WAN IP doesnt match the WAN ip of the actual hdhomerun units.

The libhdhomerun api makes it so we can quite easily provide a specific IP for the search to look at for a device (and all the associated tuner info).

All ive added is a setting to enter an address, we than supply that address to a search. This will only work for ipv4 addresses. Ive made no attempt at supporting ipv6 (who uses ipv6 on LANs?).
This also doesnt support multiple units, just a single one unlike the normal search methods. This might be something to add later, but i think this use case isnt going to be common, and realistically we should probably look at the multiple provider stuff in Kodi now for multiple tuners.

Tested functional on x86_64 macos running Nexus RC2