### PR TITLE
fix: API URL changed [Omega]

### DIFF
--- a/src/HDHomeRunTuners.cpp
+++ b/src/HDHomeRunTuners.cpp
@@ -238,7 +238,7 @@ bool HDHomeRunTuners::Update(int nMode)
     //
     if (nMode & UpdateGuide)
     {
-      strUrl = kodi::tools::StringUtils::Format("https://my.hdhomerun.com/api/guide.php?DeviceAuth=%s", EncodeURL(pTuner->Device.device_auth).c_str());
+      strUrl = kodi::tools::StringUtils::Format("https://api.hdhomerun.com/api/guide.php?DeviceAuth=%s", EncodeURL(pTuner->Device.device_auth).c_str());
       KODI_LOG(ADDON_LOG_DEBUG, "Requesting HDHomeRun guide: %s", strUrl.c_str());
 
       if (GetFileContents(strUrl.c_str(), strJson))


### PR DESCRIPTION
One person says the my.homerun.com domain name was deprecated years ago. SiliconDust terminated it July 12, 2025.

A Piers branch PR will come next.